### PR TITLE
TensorRT Deployment for NVIDIA DRIVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ FB-BEV and FB-OCC are a family of vision-centric 3D object detection and occupan
 - [Installation](docs/install.md)
 - [Prepare Dataset](docs/prepare_datasets.md)
 - [Training, Eval, Visualization](docs/start.md)
+- [Deployment on NVIDIA DRIVE Platform with TensorRT](deployment)
  
 ## Model Zoo
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,206 @@
+# FB-OCC TensorRT Deployment on NVIDIA DRIVE Platform
+
+
+This section provides the workflow to deploy  **FB-OCC** on the NVIDIA DRIVE platform using **TensorRT** from model export to inference using TensorRT. It includes all necessary components to streamline the process from model export to execution on TensorRT for NVIDIA DRIVE deployments.
+
+## Occupancy Prediction on NuScenes dataset
+
+   The model [configuration](../occupancy_configs/fb_occ/fbocc-r50-cbgs_depth_16f_16x4_20e_trt.py) to export ONNX file for TensorRT inference is based on the [original configuration](../occupancy_configs/fb_occ/fbocc-r50-cbgs_depth_16f_16x4_20e.py) with modifications.
+
+   - Input resolution: 6 cameras with resolution 256 × 704, forming an input tensor of size 6 × 3 × 256 × 704.
+   - Backbone: ResNet-50, consistent with the original configuration.
+   - Latency benchmarks on **NVIDIA DRIVE Orin** are measured with NuScenes validation samples.
+
+
+
+      |    Model  |    Framework                  | Precision     | mIoU              |  Latency (ms)   |
+      |-----------|-----------|---------------|-------------------|--------------------------------------|
+      | FB-OCC|[PyTorch](https://github.com/NVlabs/FB-BEV/tree/main?tab=readme-ov-file#model-zoo)       | FP32          | 39.10             | 767.85                                   |
+      | FB-OCC|TensorRT      | FP32          | 38.90             | 209.27                               |
+      | FB-OCC|TensorRT      | FP16          | 38.86             | 147.54                               |
+
+
+
+## Generate ONNX file and Save Input Data
+
+   Before exporting, ensure that you have completed the steps in [Installation Guide](../docs/install.md) and [Dataset Preparation Guide](../docs/prepare_datasets.md), and that the FB-OCC environment is correctly set up.
+
+   ### Docker Environment Setup (Optional)
+
+   A Docker environment is provided for your convenience to export the ONNX model.
+   
+   ```bash
+   # Build the Docker image
+   docker build -f deployment/docker/Dockerfile -t fb-occ-export .
+   # Run the container and mount the local project directory
+   docker run -it --privileged --network=host --user root --gpus all -v /path/to/FB-BEV/:/FB-BEV/ fb-occ-export /bin/bash
+   # Install FB-OCC from the source code inside the container
+   cd /FB-BEV/
+   pip install -e . 
+   ```
+   
+   ### Third-Party Custom Operations for TensorRT
+
+   FB-OCC uses operations that are not natively supported by TensorRT, including `GridSample3D` and `BevPoolv2`. To address this, you can utilize a third-party [repository](https://github.com/DerryHub/BEVFormer_tensorrt), which provides the required functionalities.
+   Follow the steps below to integrate these custom operations and generate the ONNX file:
+
+   Clone the repository and check out the specific commit for compatibility:
+   ```bash
+   # Clone the BEVFormer_tensorrt repository
+   git clone https://github.com/DerryHub/BEVFormer_tensorrt
+   cd BEVFormer_tensorrt
+   # Checkout the specific commit for compatibility
+   git checkout 303d314
+   ```
+
+   Copy the required custom operation files to your project:
+   ```bash
+   cd /path/to/FB-BEV/ 
+   mkdir -p TensorRT/plugin
+   cp -r /path/to/BEVFormer_tensorrt/TensorRT/common TensorRT/
+   cp -r /path/to/BEVFormer_tensorrt/TensorRT/plugin/bev_pool_v2 TensorRT/plugin
+   cp -r /path/to/BEVFormer_tensorrt/TensorRT/plugin/grid_sampler TensorRT/plugin
+   cp /path/to/BEVFormer_tensorrt/det2trt/models/functions/bev_pool_v2.py mmdet3d/models/fbbev/custom_ops/
+   cp /path/to/BEVFormer_tensorrt/det2trt/models/functions/grid_sampler.py mmdet3d/models/fbbev/custom_ops/
+   cp /path/to/BEVFormer_tensorrt/det2trt/models/functions/multi_scale_deformable_attn.py mmdet3d/models/fbbev/custom_ops/
+   ```
+
+   Apply the patch to adapt these custom operations to FB-OCC in order to be later consumed by TensorRT for deployment:
+   ```bash
+   git apply deployment/fbocc_custom_ops_plugin.patch
+   ```
+
+   ### ONNX Generation
+
+   Run the following command to create the ONNX model file for FB-OCC:
+   ```bash
+   python deployment/pth2onnx.py occupancy_configs/fb_occ/fbocc-r50-cbgs_depth_16f_16x4_20e_trt.py
+   ```
+
+   The command will generate the ONNX model file at `data/onnx/fbocc-r50-cbgs_depth_16f_16x4_20e_trt.onnx`.
+   This script also dumps input data at `data/trt_inputs/` which will be needed later to create the TensorRT engine.
+
+
+## TensorRT Plugin Cross-Compilation for DRIVE Orin on x86 host
+
+   This model is to be deployed on NVIDIA DRIVE Orin with TensorRT **10.8.0.37**.
+   We will use the following NVIDIA DRIVE docker image ``drive-agx-orin-linux-aarch64-pdk-build-x86:6.5.1.0-latest`` as the cross-compile environment, this container will be referred to as the build container.
+   To gain access to the docker image and the corresponding TensorRT, please join the [DRIVE AGX SDK Developer Program](https://developer.nvidia.com/drive/agx-sdk-program). You can find more details on [NVIDIA Drive](https://developer.nvidia.com/drive) site.
+
+   Launch the docker with the following command:
+   ```bash
+   docker run --gpus all -it --network=host --rm \
+     -v /path/to/FB-BEV/:/FB-BEV \
+     nvcr.io/drive/driveos-sdk/drive-agx-orin-linux-aarch64-pdk-build-x86:6.5.1.0-latest
+   ```
+
+   Inside the Docker container, execute the following commands to install the necessary components and build the plugins:   
+   ```bash
+   cd /FB-BEV/TensorRT/
+   # Set the TensorRT path
+   export TRT_PATH=/path/to/TensorRT
+   make clean all
+   ```
+
+   After compilation, the plugin file will be generated at `/drive/bin/aarch64/fb-occ_trt_plugin_aarch64.so`. 
+   This file will be used in subsequent steps to create the TensorRT engine.
+
+   
+## Build TensorRT Engine on DRIVE Orin
+
+We assume the DRIVE Orin target is prepared. For more details, please refer to [Installation Guide](https://developer.nvidia.com/docs/drive/drive-os/6.0.10/public/drive-os-linux-installation/index.html) to prepare the target.
+
+
+Prepare and transfer the required files:
+- ONNX file: `fbocc-r50-cbgs_depth_16f_16x4_20e_trt.onnx`
+- Compiled plugin: `fb-occ_trt_plugin_aarch64.so`
+- Input data: Files saved in `/path/to/FB-BEV/data/trt_inputs/`
+- Shell script: `create_trt_engine.sh` saved in `/path/to/FB-BEV/deployment/`
+   
+
+Navigate to your workspace on the target platform and execute the following commands to create the TensorRT engine:
+
+   ```bash
+   cd /path/to/workspace/
+   chmod +x create_trt_engine.sh
+
+   # FP32 engine creation 
+   ./deployment/create_trt_engine.sh \
+      --trt_path /path/to/TensorRT \
+      --data_dir /path/to/trt_inputs \
+      --onnx /path/to/fbocc-r50-cbgs_depth_16f_16x4_20e_trt.onnx \
+      --trt_plugin_path /path/to/fb-occ_trt_plugin_aarch64.so \
+      --trt_engine_path /path/to/output/fb-occ_trt_engine_fp32.plan
+
+   # FP16 engine creation 
+   ./deployment/create_trt_engine.sh \
+      --trt_path /path/to/TensorRT \
+      --data_dir /path/to/trt_inputs \
+      --onnx /path/to/fbocc-r50-cbgs_depth_16f_16x4_20e_trt.onnx \
+      --trt_plugin_path /path/to/fb-occ_trt_plugin_aarch64.so \
+      --trt_engine_path /path/to/output/fb-occ_trt_engine_fp16.plan \
+      --fp16
+   ```
+
+   Upon successful execution, the TensorRT engine will be saved as specified for `--trt_engine_path`.
+
+   #### **Notes:**
+
+   - **Real Data Requirement:** Ensure real data samples are available and properly configured (e.g., .dat files) to avoid errors during engine creation. The model uses dynamic input sizes for multiple inputs.
+   - **Dataset Configuration:** Confirm that the dataset paths for the input files are correctly set up to ensure smooth engine creation.
+
+## TensorRT Engine Evaluation on DRIVE Orin
+
+   The process involves preparing data on an x86 host, running inference on the Orin platform, and returning to the x86 host to evaluate the results and validate the TensorRT engine.
+
+   1. **Preprocess Test Data on x86 Host** 
+   
+      Prepare all test data on the x86 host by preprocessing it into `.dat` files. Define `--save_dir` as the path to save the preprocessed data.
+
+      ```bash
+      cd /path/to/FB-BEV/
+      python deployment/eval_orin/preprocess_samples.py \
+         occupancy_configs/fb_occ/fbocc-r50-cbgs_depth_16f_16x4_20e_trt.py \
+         --save_dir /path/to/preprocessed_data
+      ```
+
+   2. **Perform TensorRT Inference on DRIVE Orin**
+   
+      Mount the preprocessed data and workspace while flashing to DRIVE Orin. 
+
+      Run the shell script in the Docker container to perform TensorRT inference, saving outputs to the `--data_dir` for evaluation.
+
+      ```bash
+      cd /path/to/FB-BEV/
+      chmod +x deployment/eval_orin/run_data_trt.sh
+
+      # Run evaluation with FP32 precision TensorRT engine
+      ./deployment/eval_orin/run_data_trt.sh \
+         --trt_path /path/to/TensorRT \
+         --data_dir /path/to/preprocessed_data \
+         --trt_plugin_path /path/to/fb-occ_trt_plugin_aarch64.so \
+         --trt_engine_path /path/to/fb-occ_trt_engine_fp32.plan
+      
+      # Run evaluation with FP16 precision TensorRT engine
+      ./deployment/eval_orin/run_data_trt.sh \
+         --trt_path /path/to/TensorRT \
+         --data_dir /path/to/preprocessed_data \
+         --trt_plugin_path /path/to/fb-occ_trt_plugin_aarch64.so \
+         --trt_engine_path /path/to/fb-occ_trt_engine_fp16.plan
+      ```
+
+   3. **Transfer Outputs to x86 and Evaluate**
+      
+      
+      Transfer the inference outputs from Orin to the x86 host, postprocess them, and compute accuracy metrics to validate the TensorRT engine.
+
+      To evaluate the TensorRT engine's accuracy, execute the following command:
+
+      ```bash
+      cd /path/to/FB-BEV/
+      python tools/test.py \
+      occupancy_configs/fb_occ/fbocc-r50-cbgs_depth_16f_16x4_20e_trt.py \
+      ckpts/fbocc-r50-cbgs_depth_16f_16x4_20e.pth \
+      --target_eval \
+      --data_dir /path/to/preprocessed_data
+      ```

--- a/deployment/create_trt_engine.sh
+++ b/deployment/create_trt_engine.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Function to install numpy if not already installed
+install_numpy() {
+    if ! python3 -c "import numpy" &> /dev/null; then
+        echo "Installing numpy..."
+        sudo apt-get update
+        sudo apt-get install -y python3-pip
+        pip3 install numpy
+    else
+        echo "numpy is already installed."
+    fi
+}
+
+# Parse arguments
+DATA_DIR="data/trt_inputs"
+ONNX="data/onnx/fbocc-r50-cbgs_depth_16f_16x4_20e_trt.onnx"
+TRT_PATH="/usr/src/tensorrt"
+TRT_PLUGIN_PATH="fb-occ_trt_plugin_aarch64.so"
+TRT_ENGINE_PATH="fbocc-r50-cbgs_depth_16f_16x4_20e_trt_fp32.plan"
+FP16=false
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --data_dir) DATA_DIR="$2"; shift ;;
+        --onnx) ONNX="$2"; shift ;;
+        --trt_path) TRT_PATH="$2"; shift ;;
+        --trt_plugin_path) TRT_PLUGIN_PATH="$2"; shift ;;
+        --trt_engine_path) TRT_ENGINE_PATH="$2"; shift ;;
+        --fp16) FP16=true ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Install numpy if not already installed
+install_numpy
+
+# Determine shapes using numpy
+RANKS_SHAPE=$(python3 -c "import numpy as np; print(np.load('${DATA_DIR}/ranks_bev.npy').shape[0])")
+INTERVAL_SHAPE=$(python3 -c "import numpy as np; print(np.load('${DATA_DIR}/interval_starts.npy').shape[0])")
+INDEXES_SHAPE=$(python3 -c "import numpy as np; print(np.load('${DATA_DIR}/indexes.npy').shape[2])")
+
+# Construct the base command
+TRTEXEC_CMD="${TRT_PATH}/bin/trtexec "
+if [ "$FP16" = true ]; then
+    TRTEXEC_CMD+=" --fp16"
+fi
+
+# Construct paths
+ONNX_PATH=" --onnx=${ONNX}"
+PLUGIN_PATH=" --plugins=${TRT_PLUGIN_PATH}"
+SAVE_ENGINE_PATH=" --saveEngine=${TRT_ENGINE_PATH}"
+# SAVE_ENGINE_PATH=""
+
+# Load inputs and shapes
+LOAD_INPUTS="--loadInputs=imgs:${DATA_DIR}/imgs.dat,mlp_input:${DATA_DIR}/mlp_input.dat,ranks_depth:${DATA_DIR}/ranks_depth.dat,ranks_feat:${DATA_DIR}/ranks_feat.dat,ranks_bev:${DATA_DIR}/ranks_bev.dat,interval_starts:${DATA_DIR}/interval_starts.dat,interval_lengths:${DATA_DIR}/interval_lengths.dat,ref_2d:${DATA_DIR}/ref_2d.dat,reference_points_cam:${DATA_DIR}/reference_points_cam.dat,per_cam_mask_list:${DATA_DIR}/per_cam_mask_list.dat,indexes:${DATA_DIR}/indexes.dat,queries_rebatch:${DATA_DIR}/queries_rebatch.dat,reference_points_rebatch:${DATA_DIR}/reference_points_rebatch.dat,bev_query_depth_rebatch:${DATA_DIR}/bev_query_depth_rebatch.dat,start_of_sequence:${DATA_DIR}/start_of_sequence.dat,grid:${DATA_DIR}/grid.dat,history_bev:${DATA_DIR}/history_bev.dat,history_seq_ids:${DATA_DIR}/history_seq_ids.dat,history_sweep_time:${DATA_DIR}/history_sweep_time.dat"
+
+OPT_SHAPES="--optShapes=ranks_bev:${RANKS_SHAPE},ranks_depth:${RANKS_SHAPE},ranks_feat:${RANKS_SHAPE},interval_starts:${INTERVAL_SHAPE},interval_lengths:${INTERVAL_SHAPE},indexes:1x6x${INDEXES_SHAPE},queries_rebatch:1x6x${INDEXES_SHAPE}x80,reference_points_rebatch:1x6x${INDEXES_SHAPE}x4x2,bev_query_depth_rebatch:1x6x${INDEXES_SHAPE}x4x1"
+
+MIN_SHAPES="--minShapes=ranks_bev:170000,ranks_depth:170000,ranks_feat:170000,interval_starts:45000,interval_lengths:45000,indexes:1x6x1000,queries_rebatch:1x6x1000x80,reference_points_rebatch:1x6x1000x4x2,bev_query_depth_rebatch:1x6x1000x4x1"
+
+MAX_SHAPES="--maxShapes=ranks_bev:250000,ranks_depth:250000,ranks_feat:250000,interval_starts:60000,interval_lengths:60000,indexes:1x6x4000,queries_rebatch:1x6x4000x80,reference_points_rebatch:1x6x4000x4x2,bev_query_depth_rebatch:1x6x4000x4x1"
+
+# Combine all parts to form the final command
+FINAL_CMD="${TRTEXEC_CMD}${ONNX_PATH}${PLUGIN_PATH}${SAVE_ENGINE_PATH} ${LOAD_INPUTS} ${OPT_SHAPES} ${MIN_SHAPES} ${MAX_SHAPES}"
+
+# Execute the command
+echo "Executing command: $FINAL_CMD"
+eval $FINAL_CMD

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,0 +1,50 @@
+ARG CUDA_VERSION=11.8.0
+ARG OS_VERSION=20.04
+
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-devel-ubuntu${OS_VERSION}
+
+SHELL ["/bin/bash", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install requried libraries
+RUN apt-get update && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt-get update && apt-get install -y --no-install-recommends git
+    
+# Install python3
+RUN apt-get install -y --no-install-recommends \
+      python3 \
+      python3-pip \
+      python3-dev \
+      python3-wheel &&\
+    cd /usr/local/bin &&\
+    ln -s /usr/bin/python3 python &&\
+    ln -s /usr/bin/pip3 pip;
+    
+# Install PyPI packages
+RUN pip3 install --upgrade pip
+RUN pip3 install netron numba==0.48.0 numpy==1.20.0 nuscenes_devkit==1.1.9 Pillow==9.5.0 pycuda==2022.1 pyquaternion==0.9.9 \
+    scipy==1.7.3 setuptools==59.8.0 Shapely==1.8.4 tqdm==4.64.0 opencv-python==4.5.5.64 \
+    yapf==0.40.1 onnx_graphsurgeon onnx spconv 
+
+RUN apt-get install -y libgl1-mesa-glx
+
+# Install PyTorch
+RUN pip3 install torch==1.12.1+cu116 torchvision==0.13.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116 
+
+# Install MMLab
+ARG TORCH_CUDA_ARCH_LIST="7.5;6.1;8.6"
+ENV FORCE_CUDA="1"
+
+RUN cd / && \
+    git clone https://github.com/open-mmlab/mmcv.git && \
+    cd mmcv && git checkout v1.5.2 && \
+    pip3 install -r requirements/optional.txt && \
+    MMCV_WITH_OPS=1 pip3 install -e .
+
+RUN cd / && \
+    git clone https://github.com/open-mmlab/mmdetection.git && \
+    cd mmdetection && git checkout v2.24.0 && \
+    pip3 install -v -e .
+
+RUN pip3 install mmsegmentation==0.24.0 

--- a/deployment/eval_orin/__init__.py
+++ b/deployment/eval_orin/__init__.py
@@ -1,0 +1,2 @@
+from preprocess_samples import *
+from validate_trt_outputs import *

--- a/deployment/eval_orin/preprocess_samples.py
+++ b/deployment/eval_orin/preprocess_samples.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2022-2024, NVIDIA Corporation & Affiliates. All rights reserved. 
+# 
+# This work is made available under the Nvidia Source Code License-NC. 
+# To view a copy of this license, visit 
+# https://github.com/NVlabs/FB-BEV/blob/main/LICENSE
+
+import os
+import sys
+sys.path.append(".")
+import numpy as np
+import argparse
+import torch
+from tqdm import tqdm
+
+from mmcv import Config
+from mmcv.runner import load_checkpoint
+
+from mmdet3d.models.builder import build_model
+from mmdet3d.datasets.builder import build_dataloader, build_dataset
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Convert PyTorch to ONNX")
+    parser.add_argument("config", help="test config file path")
+    parser.add_argument("--checkpoint", default='ckpts/fbocc-r50-cbgs_depth_16f_16x4_20e.pth', help="checkpoint file")
+    parser.add_argument("--save_dir", default='data/preproc_data/', help="path to save preprocessed input data for TRT-engine creation")
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    config = Config.fromfile(args.config)
+
+    # Create required directories
+    os.makedirs(args.save_dir, exist_ok=True)
+
+    # Build the dataloader
+    test_dataloader_defaults = dict(samples_per_gpu=1, workers_per_gpu=1, dist=False, shuffle=False)
+    test_loader_cfg = {**test_dataloader_defaults, **config.data.get('test_dataloader', {})}
+    dataset = build_dataset(config.data.test)
+    data_loader = build_dataloader(dataset, **test_loader_cfg)
+   
+    # Build the model and load the checkpoint
+    config.model.train_cfg = None  # Ensure model is in evaluation mode
+    model = build_model(config.model, test_cfg=config.get('test_cfg'))
+    model.forward = model.forward_trt
+
+    _ = load_checkpoint(
+        model, args.checkpoint, map_location='cpu', revise_keys=[(r'^module\.', ''), (r'^teacher\.', '')]
+    )
+    print("Checkpoint weights loaded successfully.")
+
+    model.eval()
+    
+    # Get a sample from the data loader
+    for idx, data in tqdm(enumerate(data_loader), total=len(data_loader), desc="Processing Batches"):
+        # Extract and prepare input data
+        inputs = [t for t in data['img_inputs'][0]]
+        meta = data['img_metas'][0].data
+        seq_group_idx = int(meta[0][0]['sequence_group_idx'])
+        start_seq = meta[0][0]['start_of_sequence']
+        curr_to_prev_ego_rt = torch.stack([meta[0][0]['curr_to_prev_ego_rt']])
+        seq_ids = torch.LongTensor([seq_group_idx])
+        start_of_sequence = torch.BoolTensor([start_seq])
+
+        # Preprocess inputs
+        with torch.no_grad():
+            # Prepare model-specific inputs
+            mlp_input = model.prepare_mlp_inputs(inputs[1:7])
+            ranks_bev, ranks_depth, ranks_feat, interval_starts, interval_lengths = model.prepare_bevpool_inputs(inputs[1:7])
+            (
+                ref_2d, bev_query_depth, reference_points_cam, per_cam_mask_list, indexes, index_len,
+                queries_rebatch, reference_points_rebatch, bev_query_depth_rebatch
+            ) = model.prepare_bwdproj_inputs(inputs[1:7])
+
+            # Generate forward augmentations and history data
+            forward_augs = model.generate_forward_augs(inputs[-1])
+            history_bev = torch.zeros(config.output_shapes['output_history_bev'])
+            history_seq_ids = seq_ids
+            history_forward_augs = forward_augs.clone()
+            history_sweep_time = history_bev.new_zeros(history_bev.shape[0], model.history_cat_num) 
+            start_of_sequence = torch.BoolTensor([True])
+
+            # Prepare the grid
+            grid = model.generate_grid(history_forward_augs, forward_augs, curr_to_prev_ego_rt, config.grid_size, dtype=forward_augs.dtype, device=forward_augs.device)
+
+
+        inputs_ = dict(
+            imgs=inputs[0].detach().cpu().numpy(),
+            mlp_input=mlp_input.detach().cpu().numpy(), 
+            ranks_depth=ranks_depth.detach().cpu().numpy(), 
+            ranks_feat=ranks_feat.detach().cpu().numpy(),
+            ranks_bev=ranks_bev.detach().cpu().numpy(), 
+            interval_starts=interval_starts.detach().cpu().numpy(), 
+            interval_lengths=interval_lengths.detach().cpu().numpy(), 
+            ref_2d=ref_2d.detach().cpu().numpy(), 
+            bev_query_depth=bev_query_depth.detach().cpu().numpy(),
+            reference_points_cam=reference_points_cam.detach().cpu().numpy(), 
+            per_cam_mask_list=per_cam_mask_list.detach().cpu().numpy(),
+            indexes=indexes.detach().cpu().numpy(), 
+            queries_rebatch=queries_rebatch.detach().cpu().numpy(),
+            reference_points_rebatch=reference_points_rebatch.detach().cpu().numpy(), 
+            bev_query_depth_rebatch=bev_query_depth_rebatch.detach().cpu().numpy(),
+            start_of_sequence=start_of_sequence.detach().cpu().numpy(),
+            grid=grid.detach().cpu().numpy(),
+            history_bev=history_bev.detach().cpu().numpy(),
+            history_seq_ids=history_seq_ids.detach().cpu().numpy().astype(np.int32),
+            history_sweep_time=history_sweep_time.detach().cpu().numpy().astype(np.int32)
+            )
+
+        for key in inputs_.keys():
+
+            # Create directory for current index
+            idx_save_dir = os.path.join(args.save_dir, str(idx))
+            os.makedirs(idx_save_dir, exist_ok=True)
+
+            # Save as .dat file (skip 'history_bev')
+            if key != 'history_bev':
+                dat_file_path = os.path.join(idx_save_dir, f"{key}.dat")
+                inputs_[key].tofile(dat_file_path)
+
+                # For specific keys, save as .npy as well
+                if key in ['ranks_bev', 'interval_starts', 'indexes']:
+                    npy_file_path = os.path.join(idx_save_dir, f"{key}.npy")
+                    np.save(npy_file_path, inputs_[key])
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/deployment/eval_orin/run_data_trt.sh
+++ b/deployment/eval_orin/run_data_trt.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Parse arguments
+DATA_DIR="path/to/preprocessed_data"
+TRT_PATH="/usr/src/tensorrt"
+TRT_PLUGIN_PATH="/path/to/plugin.so"
+TRT_ENGINE_PATH="/path/to/tensorrt_engine.engine"
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --data_dir) DATA_DIR="$2"; shift ;;
+        --trt_path) TRT_PATH="$2"; shift ;;
+        --trt_plugin_path) TRT_PLUGIN_PATH="$2"; shift ;;
+        --trt_engine_path) TRT_ENGINE_PATH="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+export LD_LIBRARY_PATH=${TRT_PATH}/lib:$LD_LIBRARY_PATH 
+
+# Install numpy if not already installed
+if ! python3 -c "import numpy" &> /dev/null; then
+    echo "Installing numpy..."
+    sudo apt-get update
+    sudo apt-get install -y python3-pip
+    pip3 install numpy
+else
+    echo "numpy is already installed."
+fi
+
+# Initialize history_bev.dat with zeros
+HISTORY_BEV_PATH="${DATA_DIR}/history_bev.dat"
+python3 - <<END
+import numpy as np
+import os
+history_bev = np.zeros([1, 1280, 8, 100, 100], dtype=np.float32)
+history_bev.tofile('${HISTORY_BEV_PATH}')
+print(f"Initialized history_bev.dat at ${HISTORY_BEV_PATH}")
+END
+
+# Get a numerically sorted list of directories
+dirs=($(ls -1v "$DATA_DIR"))
+
+# Get the total number of folders
+num_folders=${#dirs[@]}
+
+# Iterate over the indices of the numerically sorted directories
+for idx_dir in "${!dirs[@]}"; do
+    dir_name="${dirs[idx_dir]}"
+    dir_path="${DATA_DIR}/${dir_name}"
+
+    if [ -d "$dir_path" ]; then
+        idx=$(basename "$dir_name")
+
+        # Build the `trtexec` command for the current data index
+        TRTEXEC_CMD="${TRT_PATH}/bin/trtexec"
+
+        PLUGIN_FLAG="--plugins=${TRT_PLUGIN_PATH}"
+        ENGINE_FLAG="--loadEngine=${TRT_ENGINE_PATH}"
+
+        # Specify output file path
+        OUTPUT_FILE="${dir_path}/output_.json"
+
+        # Determine shapes using numpy
+        RANKS_SHAPE=$(python3 -c "import numpy as np; print(np.load('${dir_path}/ranks_bev.npy').shape[0])")
+        INTERVAL_SHAPE=$(python3 -c "import numpy as np; print(np.load('${dir_path}/interval_starts.npy').shape[0])")
+        INDEXES_SHAPE=$(python3 -c "import numpy as np; print(np.load('${dir_path}/indexes.npy').shape[2])")
+
+        # Prepare inputs for `trtexec`
+        INPUTS_FLAG="--loadInputs=imgs:${dir_path}/imgs.dat,mlp_input:${dir_path}/mlp_input.dat,ranks_depth:${dir_path}/ranks_depth.dat,ranks_feat:${dir_path}/ranks_feat.dat,ranks_bev:${dir_path}/ranks_bev.dat,interval_starts:${dir_path}/interval_starts.dat,interval_lengths:${dir_path}/interval_lengths.dat,ref_2d:${dir_path}/ref_2d.dat,reference_points_cam:${dir_path}/reference_points_cam.dat,per_cam_mask_list:${dir_path}/per_cam_mask_list.dat,indexes:${dir_path}/indexes.dat,queries_rebatch:${dir_path}/queries_rebatch.dat,reference_points_rebatch:${dir_path}/reference_points_rebatch.dat,bev_query_depth_rebatch:${dir_path}/bev_query_depth_rebatch.dat,start_of_sequence:${dir_path}/start_of_sequence.dat,grid:${dir_path}/grid.dat,history_bev:${HISTORY_BEV_PATH},history_seq_ids:${dir_path}/history_seq_ids.dat,history_sweep_time:${dir_path}/history_sweep_time.dat"
+
+        OPT_SHAPES="--optShapes=ranks_bev:${RANKS_SHAPE},ranks_depth:${RANKS_SHAPE},ranks_feat:${RANKS_SHAPE},interval_starts:${INTERVAL_SHAPE},interval_lengths:${INTERVAL_SHAPE},indexes:1x6x${INDEXES_SHAPE},queries_rebatch:1x6x${INDEXES_SHAPE}x80,reference_points_rebatch:1x6x${INDEXES_SHAPE}x4x2,bev_query_depth_rebatch:1x6x${INDEXES_SHAPE}x4x1"
+
+        MIN_SHAPES="--minShapes=ranks_bev:170000,ranks_depth:170000,ranks_feat:170000,interval_starts:45000,interval_lengths:45000,indexes:1x6x1000,queries_rebatch:1x6x1000x80,reference_points_rebatch:1x6x1000x4x2,bev_query_depth_rebatch:1x6x1000x4x1"
+
+        MAX_SHAPES="--maxShapes=ranks_bev:250000,ranks_depth:250000,ranks_feat:250000,interval_starts:60000,interval_lengths:60000,indexes:1x6x4000,queries_rebatch:1x6x4000x80,reference_points_rebatch:1x6x4000x4x2,bev_query_depth_rebatch:1x6x4000x4x1"
+
+        # Add output path flag
+        OUTPUT_FLAG="--exportOutput=${OUTPUT_FILE}"
+
+        # Combine all parts into the final command
+        FINAL_CMD="${TRTEXEC_CMD} ${PLUGIN_FLAG} ${ENGINE_FLAG} ${INPUTS_FLAG} ${OUTPUT_FLAG} ${OPT_SHAPES} ${MIN_SHAPES} ${MAX_SHAPES}"
+
+        # Execute the command
+        echo "Executing command for index ${idx}: $FINAL_CMD"
+        eval "$FINAL_CMD"
+
+        # Update history_bev.dat based on trtexec output
+        if [ -f "${OUTPUT_FILE}" ]; then
+            python3 - <<END
+import numpy as np
+import json
+import os
+
+# Load current history_bev
+history_bev_path = "${HISTORY_BEV_PATH}"
+
+# Load new output from trtexec
+output_file = "${OUTPUT_FILE}"
+with open(output_file, 'r') as f:
+    trt_output = json.load(f)
+
+# Update history_bev with new values
+new_history_bev = np.array(trt_output[1]['values'], dtype=np.float32)
+
+with open(output_file, 'w') as f:
+    json.dump(trt_output[0], f)
+    
+# Save the updated history_bev
+np.save(history_bev_path, new_history_bev)
+print(f"Updated history_bev.dat after index ${idx}")
+END
+        else
+            echo "Skipping history_bev update for index ${idx}: Output file not found."
+        fi
+    fi
+done
+
+echo "All samples processed successfully."

--- a/deployment/eval_orin/validate_trt_outputs.py
+++ b/deployment/eval_orin/validate_trt_outputs.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2022-2024, NVIDIA Corporation & Affiliates. All rights reserved. 
+# 
+# This work is made available under the Nvidia Source Code License-NC. 
+# To view a copy of this license, visit 
+# https://github.com/NVlabs/FB-BEV/blob/main/LICENSE
+
+import os
+import json
+import torch
+import numpy as np
+import mmcv
+from tqdm import tqdm
+
+def eval_trt_target(model, data_loader, data_dir):
+    """
+    Test a model using precomputed TensorRT outputs stored in JSON files.
+
+    Args:
+        model (nn.Module): The model to test.
+        data_loader (DataLoader): DataLoader for the dataset.
+        data_dir (str): Directory containing TensorRT output JSON files for each data sample.
+
+    Returns:
+        list: Results for the dataset.
+    """
+    model.eval()
+    results = []
+    dataset = data_loader.dataset
+    prog_bar = mmcv.ProgressBar(len(dataset))
+
+    for idx, data in tqdm(enumerate(data_loader), total=len(data_loader), desc="Processing Batches"):
+        with torch.no_grad():
+            meta = data['img_metas'][0].data
+            trt_output_file = os.path.join(data_dir, str(idx), "output_.json")
+
+            if not os.path.exists(trt_output_file):
+                print(f"Skipping index {idx}: TensorRT output file not found.")
+                continue
+
+            # Load TensorRT outputs from JSON
+            with open(trt_output_file, "r") as f:
+                trt_exports = json.load(f)
+
+            # Load pred_occupancy from the JSON file
+            pred_occupancy = np.array(trt_exports['values'], dtype=np.float32)
+
+            # Convert pred_occupancy to a torch tensor for post-processing
+            pred_occupancy = torch.from_numpy(pred_occupancy)
+
+            # Post-process the predictions
+            result_dict_list = model.post_process(pred_occupancy)
+            result_dict_list[0]['index'] = meta[0][0]['index']
+            results.extend(result_dict_list)
+
+            # Update the progress bar
+            batch_size = pred_occupancy.size(0)
+            for _ in range(batch_size):
+                prog_bar.update()
+
+    return results

--- a/deployment/fbocc_custom_ops_plugin.patch
+++ b/deployment/fbocc_custom_ops_plugin.patch
@@ -1,0 +1,565 @@
+diff --git a/TensorRT/Makefile b/TensorRT/Makefile
+new file mode 100644
+index 0000000..3837ac4
+--- /dev/null
++++ b/TensorRT/Makefile
+@@ -0,0 +1,60 @@
++# Define paths
++CUDA_DIR ?= /usr/local/cuda
++DLSW_TRIPLE = aarch64-linux-gnu
++TRT_PATH ?= /usr/src/tensorrt/
++TRT_LIB_DIR := $(TRT_PATH)/lib
++TRT_INC_DIR := $(TRT_PATH)/include
++SYSROOT ?= 
++OUTPUT_DIR ?= build
++
++# Compiler and flags
++CXX := aarch64-linux-gnu-g++
++NVCC := $(CUDA_DIR)/bin/nvcc
++
++CXXFLAGS := -std=c++14 -O3 -Wno-deprecated-declarations -fPIC \
++    -I$(TRT_INC_DIR)/ \
++    -I$(CUDA_DIR)/include \
++    -I$(SYSROOT)/include \
++    -Icommon \
++
++NVCCFLAGS := -std=c++14 --compiler-options '-fPIC' \
++    -I$(TRT_INC_DIR)/ \
++    -I$(CUDA_DIR)/include \
++    -I$(SYSROOT)/include \
++    -Icommon \
++    -gencode arch=compute_87,code=sm_87
++
++NVCCFLAGS += --compiler-bindir=/usr/bin/aarch64-linux-gnu-g++
++
++# Library paths and libraries
++LDFLAGS := -L$(TRT_LIB_DIR)  -L$(CUDA_DIR)/targets/aarch64-linux/lib
++LDLIBS := -lnvinfer -lnvinfer_plugin -lcudart 
++
++# Source and object files
++CPP_SRCS := $(wildcard common/*.cpp plugin/bev_pool_v2/*.cpp plugin/grid_sampler/*.cpp)
++CU_SRCS := $(wildcard common/*.cu plugin/bev_pool_v2/*.cu plugin/grid_sampler/*.cu)
++CPP_OBJS := $(addprefix $(OUTPUT_DIR)/, $(CPP_SRCS:.cpp=.o))
++CU_OBJS := $(addprefix $(OUTPUT_DIR)/, $(CU_SRCS:.cu=.o))
++
++# Output shared library
++OUTPUT_LIB := ./fb-occ_trt_plugin_aarch64.so
++
++# Rules
++all: $(OUTPUT_DIR) $(OUTPUT_LIB)
++
++$(OUTPUT_DIR):
++	mkdir -p $(OUTPUT_DIR)
++
++$(OUTPUT_DIR)/%.o: %.cpp
++	mkdir -p $(dir $@)
++	$(CXX) $(CXXFLAGS) -c $< -o $@
++
++$(OUTPUT_DIR)/%.o: %.cu
++	mkdir -p $(dir $@)
++	$(NVCC) $(NVCCFLAGS) -c $< -o $@
++
++$(OUTPUT_LIB): $(CPP_OBJS) $(CU_OBJS)
++	$(CXX) -shared -o $@ $^ $(LDFLAGS) $(LDLIBS)
++
++clean:
++	rm -rf $(OUTPUT_DIR)
+diff --git a/TensorRT/plugin/bev_pool_v2/bevPoolKernel.cu b/TensorRT/plugin/bev_pool_v2/bevPoolKernel.cu
+index 6697df9..d599835 100644
+--- a/TensorRT/plugin/bev_pool_v2/bevPoolKernel.cu
++++ b/TensorRT/plugin/bev_pool_v2/bevPoolKernel.cu
+@@ -19,10 +19,10 @@
+ template <typename T>
+ __global__ void bev_pool_v2_kernel(
+     int c, int n_intervals, const T *__restrict__ depth,
+-    const T *__restrict__ feat, const int *__restrict__ ranks_depth,
+-    const int *__restrict__ ranks_feat, const int *__restrict__ ranks_bev,
+-    const int *__restrict__ interval_starts,
+-    const int *__restrict__ interval_lengths, T *__restrict__ out) {
++    const T *__restrict__ feat, const TRT_INT *__restrict__ ranks_depth,
++    const TRT_INT *__restrict__ ranks_feat, const TRT_INT *__restrict__ ranks_bev,
++    const TRT_INT *__restrict__ interval_starts,
++    const TRT_INT *__restrict__ interval_lengths, T *__restrict__ out) {
+   int idx = blockIdx.x * blockDim.x + threadIdx.x;
+   int index = idx / c;
+   int cur_c = idx % c;
+@@ -39,7 +39,7 @@ __global__ void bev_pool_v2_kernel(
+     psum += *cur_feat * *cur_depth;
+   }
+ 
+-  const int *cur_rank = ranks_bev + interval_start;
++  const TRT_INT *cur_rank = ranks_bev + interval_start;
+   T *cur_out = out + *cur_rank * c + cur_c;
+   *cur_out = psum;
+ }
+@@ -47,10 +47,10 @@ __global__ void bev_pool_v2_kernel(
+ template <>
+ __global__ void bev_pool_v2_kernel(
+     int c, int n_intervals, const __half *__restrict__ depth,
+-    const __half *__restrict__ feat, const int *__restrict__ ranks_depth,
+-    const int *__restrict__ ranks_feat, const int *__restrict__ ranks_bev,
+-    const int *__restrict__ interval_starts,
+-    const int *__restrict__ interval_lengths, __half *__restrict__ out) {
++    const __half *__restrict__ feat, const TRT_INT *__restrict__ ranks_depth,
++    const TRT_INT *__restrict__ ranks_feat, const TRT_INT *__restrict__ ranks_bev,
++    const TRT_INT *__restrict__ interval_starts,
++    const TRT_INT *__restrict__ interval_lengths, __half *__restrict__ out) {
+   int idx = blockIdx.x * blockDim.x + threadIdx.x;
+   int index = idx / c;
+   int cur_c = idx % c;
+@@ -67,7 +67,7 @@ __global__ void bev_pool_v2_kernel(
+     psum = __hfma(*cur_feat, *cur_depth, psum);
+   }
+ 
+-  const int *cur_rank = ranks_bev + interval_start;
++  const TRT_INT *cur_rank = ranks_bev + interval_start;
+   __half *cur_out = out + *cur_rank * c + cur_c;
+   *cur_out = psum;
+ }
+@@ -150,9 +150,9 @@ __global__ void bev_pool_v2_kernel_int8(
+ 
+ template <typename T>
+ void bev_pool_v2(int c, int n_intervals, int num_points, const T *depth,
+-                 const T *feat, const int *ranks_depth, const int *ranks_feat,
+-                 const int *ranks_bev, const int *interval_starts,
+-                 const int *interval_lengths, T *out, cudaStream_t stream) {
++                 const T *feat, const TRT_INT *ranks_depth, const TRT_INT *ranks_feat,
++                 const TRT_INT *ranks_bev, const TRT_INT *interval_starts,
++                 const TRT_INT *interval_lengths, T *out, cudaStream_t stream) {
+   cudaMemset((T *)out, 0, num_points * sizeof(T));
+   bev_pool_v2_kernel<<<GET_BLOCKS(n_intervals * c), THREADS_PER_BLOCK, 0,
+                        stream>>>(c, n_intervals, depth, feat, ranks_depth,
+@@ -191,14 +191,14 @@ void bev_pool_v2_int8(int c, int n_intervals, int num_points,
+ 
+ template void bev_pool_v2(int c, int n_intervals, int num_points,
+                           const float *depth, const float *feat,
+-                          const int *ranks_depth, const int *ranks_feat,
+-                          const int *ranks_bev, const int *interval_starts,
+-                          const int *interval_lengths, float *out,
++                          const TRT_INT *ranks_depth, const TRT_INT *ranks_feat,
++                          const TRT_INT *ranks_bev, const TRT_INT *interval_starts,
++                          const TRT_INT *interval_lengths, float *out,
+                           cudaStream_t stream);
+ 
+ template void bev_pool_v2(int c, int n_intervals, int num_points,
+                           const __half *depth, const __half *feat,
+-                          const int *ranks_depth, const int *ranks_feat,
+-                          const int *ranks_bev, const int *interval_starts,
+-                          const int *interval_lengths, __half *out,
++                          const TRT_INT *ranks_depth, const TRT_INT *ranks_feat,
++                          const TRT_INT *ranks_bev, const TRT_INT *interval_starts,
++                          const TRT_INT *interval_lengths, __half *out,
+                           cudaStream_t stream);
+diff --git a/TensorRT/plugin/bev_pool_v2/bevPoolKernel.h b/TensorRT/plugin/bev_pool_v2/bevPoolKernel.h
+index e23eb81..e12cea4 100644
+--- a/TensorRT/plugin/bev_pool_v2/bevPoolKernel.h
++++ b/TensorRT/plugin/bev_pool_v2/bevPoolKernel.h
+@@ -8,13 +8,16 @@
+ #include "cuda_int8.h"
+ #include <cuda_fp16.h>
+ #include <cuda_runtime.h>
++#include <type_traits>
++#include <NvInfer.h>
++typedef std::conditional<NV_TENSORRT_MAJOR<10, int, int64_t>::type TRT_INT;
+ 
+ // CUDA function declarations
+ template <typename T>
+ void bev_pool_v2(int c, int n_intervals, int num_points, const T *depth,
+-                 const T *feat, const int *ranks_depth, const int *ranks_feat,
+-                 const int *ranks_bev, const int *interval_starts,
+-                 const int *interval_lengths, T *out, cudaStream_t stream);
++                 const T *feat, const TRT_INT *ranks_depth, const TRT_INT *ranks_feat,
++                 const TRT_INT *ranks_bev, const TRT_INT *interval_starts,
++                 const TRT_INT *interval_lengths, T *out, cudaStream_t stream);
+ 
+ void bev_pool_v2_h2(int c, int n_intervals, int num_points, const __half *depth,
+                     const __half2 *feat, const int *ranks_depth,
+diff --git a/TensorRT/plugin/bev_pool_v2/bevPoolPlugin.cpp b/TensorRT/plugin/bev_pool_v2/bevPoolPlugin.cpp
+index 3aae089..85e8319 100644
+--- a/TensorRT/plugin/bev_pool_v2/bevPoolPlugin.cpp
++++ b/TensorRT/plugin/bev_pool_v2/bevPoolPlugin.cpp
+@@ -45,11 +45,12 @@ DimsExprs BEVPoolPlugin::getOutputDimensions(
+     int32_t outputIndex, const nvinfer1::DimsExprs *inputs, int32_t nbInputs,
+     nvinfer1::IExprBuilder &exprBuilder) noexcept {
+   nvinfer1::DimsExprs ret;
+-  ret.nbDims = 4;
++  ret.nbDims = 5;
+   ret.d[0] = exprBuilder.constant(1);
+-  ret.d[1] = exprBuilder.constant(mOutHeight);
+-  ret.d[2] = exprBuilder.constant(mOutWidth);
+-  ret.d[3] = inputs[1].d[3];
++  ret.d[1] = exprBuilder.constant(8);
++  ret.d[2] = exprBuilder.constant(mOutHeight); 
++  ret.d[3] = exprBuilder.constant(mOutWidth);
++  ret.d[4] = inputs[1].d[4];
+   return ret;
+ }
+ 
+@@ -74,31 +75,31 @@ int32_t BEVPoolPlugin::enqueue(const nvinfer1::PluginTensorDesc *inputDesc,
+   nvinfer1::Dims out_dims = outputDesc[0].dims;     // bhwc
+   auto data_type = inputDesc[0].type;
+   int num_points =
+-      out_dims.d[0] * out_dims.d[1] * out_dims.d[2] * out_dims.d[3];
++      out_dims.d[0] * out_dims.d[1] * out_dims.d[2] * out_dims.d[3] * out_dims.d[4];
+   switch (data_type) {
+   case nvinfer1::DataType::kFLOAT:
+-    bev_pool_v2(feat_dims.d[3], interval_dims.d[0], num_points,
+-                (float *)inputs[0], (float *)inputs[1], (int *)inputs[2],
+-                (int *)inputs[3], (int *)inputs[4], (int *)inputs[5],
+-                (int *)inputs[6], (float *)outputs[0], stream);
++    bev_pool_v2(feat_dims.d[4], interval_dims.d[0], num_points,
++                (float *)inputs[0], (float *)inputs[1], (TRT_INT *)inputs[2],
++                (TRT_INT *)inputs[3], (TRT_INT *)inputs[4], (TRT_INT *)inputs[5],
++                (TRT_INT *)inputs[6], (float *)outputs[0], stream);
+     break;
+   case nvinfer1::DataType::kHALF:
+     if (use_h2) {
+-      bev_pool_v2_h2(feat_dims.d[3], interval_dims.d[0], num_points,
++      bev_pool_v2_h2(feat_dims.d[4], interval_dims.d[0], num_points,
+                      (__half *)inputs[0], (__half2 *)inputs[1],
+                      (int *)inputs[2], (int *)inputs[3], (int *)inputs[4],
+                      (int *)inputs[5], (int *)inputs[6], (__half2 *)outputs[0],
+                      stream);
+     } else {
+-      bev_pool_v2(feat_dims.d[3], interval_dims.d[0], num_points,
+-                  (__half *)inputs[0], (__half *)inputs[1], (int *)inputs[2],
+-                  (int *)inputs[3], (int *)inputs[4], (int *)inputs[5],
+-                  (int *)inputs[6], (__half *)outputs[0], stream);
++      bev_pool_v2(feat_dims.d[4], interval_dims.d[0], num_points,
++                  (__half *)inputs[0], (__half *)inputs[1], (TRT_INT *)inputs[2],
++                  (TRT_INT *)inputs[3], (TRT_INT *)inputs[4], (TRT_INT *)inputs[5],
++                  (TRT_INT *)inputs[6], (__half *)outputs[0], stream);
+     }
+     break;
+   case nvinfer1::DataType::kINT8:
+     bev_pool_v2_int8(
+-        feat_dims.d[3], interval_dims.d[0], num_points, (int8_t *)inputs[0],
++        feat_dims.d[4], interval_dims.d[0], num_points, (int8_t *)inputs[0],
+         inputDesc[0].scale, (int8_4 *)inputs[1], inputDesc[1].scale,
+         (int *)inputs[2], (int *)inputs[3], (int *)inputs[4], (int *)inputs[5],
+         (int *)inputs[6], (int8_4 *)outputs[0], outputDesc[0].scale, stream);
+@@ -130,7 +131,7 @@ bool BEVPoolPlugin::supportsFormatCombination(
+     return inOut[pos].type == inOut[0].type &&
+            inOut[pos].format == inOut[0].format;
+   } else {
+-    return (inOut[pos].type == nvinfer1::DataType::kINT32 &&
++    return (inOut[pos].type == TRT_kINT && 
+             inOut[pos].format == nvinfer1::TensorFormat::kLINEAR);
+   }
+ }
+diff --git a/TensorRT/plugin/bev_pool_v2/bevPoolPlugin.h b/TensorRT/plugin/bev_pool_v2/bevPoolPlugin.h
+index 75663cd..3aea990 100644
+--- a/TensorRT/plugin/bev_pool_v2/bevPoolPlugin.h
++++ b/TensorRT/plugin/bev_pool_v2/bevPoolPlugin.h
+@@ -11,6 +11,14 @@
+ #include <cublas_v2.h>
+ #include <string>
+ #include <vector>
++#include <type_traits>
++
++#if NV_TENSORRT_MAJOR < 10
++  #define TRT_kINT nvinfer1::DataType::kINT32
++#else
++  #define TRT_kINT nvinfer1::DataType::kINT64
++#endif
++typedef std::conditional<NV_TENSORRT_MAJOR<10, int32_t, int64_t>::type TRT_INT;
+ 
+ namespace trt_plugin {
+ 
+diff --git a/TensorRT/plugin/grid_sampler/gridSamplerKernel.cu b/TensorRT/plugin/grid_sampler/gridSamplerKernel.cu
+index 4cd713f..bf0ac63 100644
+--- a/TensorRT/plugin/grid_sampler/gridSamplerKernel.cu
++++ b/TensorRT/plugin/grid_sampler/gridSamplerKernel.cu
+@@ -1922,8 +1922,9 @@ __global__ void grid_sampler_3d_kernel(
+   }
+ }
+ 
+-void create_desc(const int *dims, int nb_dims, TensorDesc &desc) {
+-  memcpy(&desc.shape[0], dims, sizeof(int) * nb_dims);
++void create_desc(const TRT_INT *dims, int nb_dims, TensorDesc &desc) {
++  // memcpy(&desc.shape[0], dims, sizeof(int) * nb_dims);
++  for (size_t dim_id=0; dim_id<nb_dims; ++dim_id) desc.shape[dim_id] = (int) dims[dim_id];
+   desc.stride[nb_dims - 1] = 1;
+   for (int i = nb_dims - 2; i >= 0; --i) {
+     desc.stride[i] = desc.stride[i + 1] * desc.shape[i + 1];
+@@ -1931,8 +1932,8 @@ void create_desc(const int *dims, int nb_dims, TensorDesc &desc) {
+ }
+ 
+ template <typename T>
+-void grid_sample(T *output, const T *input, const T *grid, int *output_dims,
+-                 int *input_dims, int *grid_dims, int nb_dims,
++void grid_sample(T *output, const T *input, const T *grid, TRT_INT *output_dims,
++                 TRT_INT *input_dims, TRT_INT *grid_dims, int nb_dims,
+                  GridSamplerInterpolation interp, GridSamplerPadding padding,
+                  bool align_corners, cudaStream_t stream) {
+   TensorDesc input_desc;
+@@ -1969,7 +1970,7 @@ void grid_sample(T *output, const T *input, const T *grid, int *output_dims,
+ 
+ template <>
+ void grid_sample(__half2 *output, const __half2 *input, const __half2 *grid,
+-                 int *output_dims, int *input_dims, int *grid_dims, int nb_dims,
++                 TRT_INT *output_dims, TRT_INT *input_dims, TRT_INT *grid_dims, int nb_dims,
+                  GridSamplerInterpolation interp, GridSamplerPadding padding,
+                  bool align_corners, cudaStream_t stream) {
+   TensorDesc input_desc;
+@@ -2009,8 +2010,8 @@ void grid_sample(__half2 *output, const __half2 *input, const __half2 *grid,
+ 
+ void grid_sample_int8(int8_4 *output, const float &scale_o, const int8_4 *input,
+                       const float &scale_i, const int8_4 *grid,
+-                      const float &scale_g, int *output_dims, int *input_dims,
+-                      int *grid_dims, int nb_dims,
++                      const float &scale_g, TRT_INT *output_dims, TRT_INT *input_dims,
++                      TRT_INT *grid_dims, int nb_dims,
+                       GridSamplerInterpolation interp,
+                       GridSamplerPadding padding, bool align_corners,
+                       cudaStream_t stream) {
+@@ -2043,22 +2044,22 @@ void grid_sample_int8(int8_4 *output, const float &scale_o, const int8_4 *input,
+ }
+ 
+ template void grid_sample<float>(float *output, const float *input,
+-                                 const float *grid, int *output_dims,
+-                                 int *input_dims, int *grid_dims, int nb_dims,
++                                 const float *grid, TRT_INT *output_dims,
++                                 TRT_INT *input_dims, TRT_INT *grid_dims, int nb_dims,
+                                  GridSamplerInterpolation interp,
+                                  GridSamplerPadding padding, bool align_corners,
+                                  cudaStream_t stream);
+ 
+ template void grid_sample<__half>(__half *output, const __half *input,
+-                                  const __half *grid, int *output_dims,
+-                                  int *input_dims, int *grid_dims, int nb_dims,
++                                  const __half *grid, TRT_INT *output_dims,
++                                  TRT_INT *input_dims, TRT_INT *grid_dims, int nb_dims,
+                                   GridSamplerInterpolation interp,
+                                   GridSamplerPadding padding,
+                                   bool align_corners, cudaStream_t stream);
+ 
+ template void grid_sample<__half2>(__half2 *output, const __half2 *input,
+-                                   const __half2 *grid, int *output_dims,
+-                                   int *input_dims, int *grid_dims, int nb_dims,
++                                   const __half2 *grid, TRT_INT *output_dims,
++                                   TRT_INT *input_dims, TRT_INT *grid_dims, int nb_dims,
+                                    GridSamplerInterpolation interp,
+                                    GridSamplerPadding padding,
+                                    bool align_corners, cudaStream_t stream);
+diff --git a/TensorRT/plugin/grid_sampler/gridSamplerKernel.h b/TensorRT/plugin/grid_sampler/gridSamplerKernel.h
+index 0a913c1..64f9879 100644
+--- a/TensorRT/plugin/grid_sampler/gridSamplerKernel.h
++++ b/TensorRT/plugin/grid_sampler/gridSamplerKernel.h
+@@ -7,20 +7,24 @@
+ 
+ #include "cuda_int8.h"
+ #include <cuda_runtime.h>
++#include <type_traits>
++#include <NvInfer.h>
++
++typedef std::conditional<NV_TENSORRT_MAJOR<10, int, int64_t>::type TRT_INT;
+ 
+ enum class GridSamplerInterpolation { Bilinear, Nearest, Bicubic };
+ enum class GridSamplerPadding { Zeros, Border, Reflection };
+ 
+ template <typename T>
+-void grid_sample(T *output, const T *input, const T *grid, int *output_dims,
+-                 int *input_dims, int *grid_dims, int nb_dims,
++void grid_sample(T *output, const T *input, const T *grid, TRT_INT *output_dims,
++                 TRT_INT *input_dims, TRT_INT *grid_dims, int nb_dims,
+                  GridSamplerInterpolation interp, GridSamplerPadding padding,
+                  bool align_corners, cudaStream_t stream);
+ 
+ void grid_sample_int8(int8_4 *output, const float &scale_o, const int8_4 *input,
+                       const float &scale_i, const int8_4 *grid,
+-                      const float &scale_g, int *output_dims, int *input_dims,
+-                      int *grid_dims, int nb_dims,
++                      const float &scale_g, TRT_INT *output_dims, TRT_INT *input_dims,
++                      TRT_INT *grid_dims, int nb_dims,
+                       GridSamplerInterpolation interp,
+                       GridSamplerPadding padding, bool align_corners,
+                       cudaStream_t stream);
+diff --git a/mmdet3d/models/fbbev/custom_ops/bev_pool_v2.py b/mmdet3d/models/fbbev/custom_ops/bev_pool_v2.py
+index 1a95bcc..e8e4708 100644
+--- a/mmdet3d/models/fbbev/custom_ops/bev_pool_v2.py
++++ b/mmdet3d/models/fbbev/custom_ops/bev_pool_v2.py
+@@ -1,6 +1,12 @@
+ from torch.autograd import Function
+-from third_party.bev_mmdet3d.ops.bev_pool_v2 import bev_pool_v2_gpu
++from mmdet3d.ops.bev_pool_v2.bev_pool import QuickCumsumCuda
+ 
++def bev_pool_v2_gpu(depth, feat, ranks_depth, ranks_feat, ranks_bev,
++                bev_feat_shape, interval_starts, interval_lengths):
++    x = QuickCumsumCuda.apply(depth, feat, ranks_depth, ranks_feat, ranks_bev,
++                              bev_feat_shape, interval_starts,
++                              interval_lengths)
++    return x
+ 
+ class _BEVPoolV2(Function):
+     @staticmethod
+@@ -43,11 +49,9 @@ class _BEVPoolV2(Function):
+         out_width,
+     ):
+         """run forward."""
+-        feat = feat.unsqueeze(0)
+-        depth = depth.unsqueeze(0)
+         bev_feat_shape = (
+             depth.shape[0],
+-            1,
++            8,
+             out_height,
+             out_width,
+             feat.shape[-1],
+@@ -62,8 +66,6 @@ class _BEVPoolV2(Function):
+             interval_starts,
+             interval_lengths,
+         )
+-        bev_feat = bev_feat.squeeze(2)
+-        bev_feat = bev_feat.permute(0, 2, 3, 1)
+         return bev_feat
+ 
+     @staticmethod
+@@ -111,17 +113,17 @@ def bev_pool_v2(
+     ranks_bev,
+     interval_starts,
+     interval_lengths,
+-    out_height=128,
+-    out_width=128,
++    out_height=100,
++    out_width=100,
+ ):
+     return _bev_pool_v2(
+         depth,  # N,D,H,W
+         feat,  # N,H,W,C
+-        ranks_depth.int(),
+-        ranks_feat.int(),
+-        ranks_bev.int(),
+-        interval_starts.int(),
+-        interval_lengths.int(),
++        ranks_depth.long(),
++        ranks_feat.long(),
++        ranks_bev.long(),
++        interval_starts.long(),
++        interval_lengths.long(),
+         out_height,
+         out_width,
+     )
+diff --git a/mmdet3d/models/fbbev/custom_ops/multi_scale_deformable_attn.py b/mmdet3d/models/fbbev/custom_ops/multi_scale_deformable_attn.py
+index 36db587..c9690f7 100644
+--- a/mmdet3d/models/fbbev/custom_ops/multi_scale_deformable_attn.py
++++ b/mmdet3d/models/fbbev/custom_ops/multi_scale_deformable_attn.py
+@@ -18,7 +18,7 @@ class _MultiScaleDeformableAttnFunction(Function):
+         attention_weights,
+     ):
+         return g.op(
+-            "MultiScaleDeformableAttnTRT",
++            "trt::MultiscaleDeformableAttnPlugin_TRT",
+             value,
+             value_spatial_shapes,
+             reference_points,
+@@ -31,88 +31,20 @@ class _MultiScaleDeformableAttnFunction(Function):
+         ctx,
+         value,
+         value_spatial_shapes,
+-        reference_points,
+-        sampling_offsets,
+-        attention_weights,
++        value_level_start_index, 
++        sampling_locations,
++        attention_weights
+     ):
+-        """GPU version of multi-scale deformable attention.
+-
+-        Args:
+-            value (Tensor): The value has shape
+-                (bs, mum_heads, embed_dims//num_heads, num_keys)
+-            value_spatial_shapes (Tensor): Spatial shape of
+-                each feature map, has shape (num_levels, 2),
+-                last dimension 2 represent (h, w)
+-            reference_points (Tensor): The reference points.
+-            sampling_offsets (Tensor): The offset of sampling points,
+-                has shape
+-                (bs, num_heads, num_queries, num_levels*num_points*2),
+-                the last dimension 2 represent (x, y).
+-            attention_weights (Tensor): The weight of sampling points used
+-                when calculate the attention, has shape
+-                (bs, num_heads, num_queries, num_levels*num_points).
+-
+-        Returns:
+-            Tensor: has shape (bs, embed_dims, num_queries)
+-        """
+-        num_heads, channel = value.shape[2:]
+-        num_level = value_spatial_shapes.shape[0]
+-        bs, num_queries = reference_points.shape[:2]
+-
+-        points_per_group = torch.div(
+-            reference_points.shape[-1], 2, rounding_mode="floor"
+-        )
+-        sampling_offsets = sampling_offsets.view(
+-            bs, num_queries, num_heads, num_level, -1, points_per_group, 2,
+-        )
+-        dim = sampling_offsets.shape[4] * num_level * 2 * points_per_group
+-        offset_normalizer = torch.stack(
+-            [value_spatial_shapes[..., 1], value_spatial_shapes[..., 0]], -1
+-        )
+-        sampling_locations = reference_points.view(
+-            bs, num_queries, 1, 1, 1, -1, 2
+-        ) + sampling_offsets / offset_normalizer.view(1, 1, 1, -1, 1, 1, 2)
+-        sampling_locations = sampling_locations.view(
+-            bs,
+-            num_queries,
+-            num_heads,
+-            num_level,
+-            torch.div(dim, num_level * 2, rounding_mode="floor"),
+-            2,
+-        )
+-        attention_weights = attention_weights.view(
+-            -1, num_level * torch.div(dim, num_level * 2, rounding_mode="floor")
+-        ).softmax(-1)
+-        attention_weights = attention_weights.view(
+-            bs,
+-            num_queries,
+-            num_heads,
+-            num_level,
+-            torch.div(dim, num_level * 2, rounding_mode="floor"),
+-        )
+-        im2col_step = value.shape[0]
++        N, S, M, D = value.shape
++        im2col_step = N
+         ctx.im2col_step = im2col_step
+-
+-        ctx.fp16 = False
+-        if value.dtype == torch.float16:
+-            ctx.fp16 = True
+-            value = value.float()
+-            sampling_locations = sampling_locations.float()
+-            attention_weights = attention_weights.float()
+-
+-        value_level_start_index = torch.zeros_like(value_spatial_shapes[:, 0])
+-        value_level_start_index[1:] = torch.cumsum(
+-            value_spatial_shapes[:, 0] * value_spatial_shapes[:, 1], dim=0
+-        )[:-1]
+-
+         output = ext_module.ms_deform_attn_forward(
+-            value,
+-            value_spatial_shapes,
+-            value_level_start_index,
+-            sampling_locations,
+-            attention_weights,
+-            im2col_step=ctx.im2col_step,
+-        ).view(bs, num_queries, num_heads, channel)
++            value, 
++            value_spatial_shapes, 
++            value_level_start_index, 
++            sampling_locations, 
++            attention_weights, 
++            im2col_step=ctx.im2col_step)
+         ctx.save_for_backward(
+             value,
+             value_spatial_shapes,
+@@ -120,7 +52,8 @@ class _MultiScaleDeformableAttnFunction(Function):
+             sampling_locations,
+             attention_weights,
+         )
+-        return output.half() if ctx.fp16 else output
++        N, Lq, _ = output.shape
++        return output.view(N, Lq, M, D)
+ 
+ 
+ class _MultiScaleDeformableAttnFunction2(_MultiScaleDeformableAttnFunction):

--- a/deployment/pth2onnx.py
+++ b/deployment/pth2onnx.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2022-2024, NVIDIA Corporation & Affiliates. All rights reserved. 
+# 
+# This work is made available under the Nvidia Source Code License-NC. 
+# To view a copy of this license, visit 
+# https://github.com/NVlabs/FB-BEV/blob/main/LICENSE
+
+import os
+import numpy as np
+import argparse
+import torch
+from torch.onnx import OperatorExportTypes
+
+from mmcv import Config
+from mmcv.runner import load_checkpoint
+
+import onnx_graphsurgeon as gs
+import onnx 
+
+import sys
+sys.path.append(".")
+
+from mmdet3d.models.builder import build_model
+from mmdet3d.datasets.builder import build_dataloader, build_dataset
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Convert PyTorch to ONNX")
+    parser.add_argument("config", help="test config file path")
+    parser.add_argument("--checkpoint", default='ckpts/fbocc-r50-cbgs_depth_16f_16x4_20e.pth', help="checkpoint file")
+    parser.add_argument("--data_dir", default='data/trt_inputs', help="path to save input data for TRT-engine creation")
+    parser.add_argument("--onnx_path", default='data/onnx', help="path to save onnx file")
+    parser.add_argument("--opset_version", default=16, type=int)
+    parser.add_argument("--cuda", default=True, type=bool)
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    config = Config.fromfile(args.config)
+
+    # Create required directories
+    os.makedirs(args.data_dir, exist_ok=True)
+    os.makedirs(args.onnx_path, exist_ok=True)
+
+    # Construct ONNX file path
+    onnx_path = os.path.join(
+        args.onnx_path, f"{os.path.splitext(os.path.basename(args.config))[0]}.onnx"
+    )
+
+    # Build the dataloader
+    test_dataloader_defaults = dict(samples_per_gpu=1, workers_per_gpu=1, dist=False, shuffle=False)
+    test_loader_cfg = {**test_dataloader_defaults, **config.data.get('test_dataloader', {})}
+    dataset = build_dataset(config.data.test)
+    data_loader = build_dataloader(dataset, **test_loader_cfg)
+   
+    # Build the model and load the checkpoint
+    config.model.train_cfg = None  # Ensure model is in evaluation mode
+    model = build_model(config.model, test_cfg=config.get('test_cfg'))
+    model.forward = model.forward_trt
+
+    _ = load_checkpoint(
+        model, args.checkpoint, map_location='cpu', revise_keys=[(r'^module\.', ''), (r'^teacher\.', '')]
+    )
+    print("Checkpoint weights loaded successfully.")
+
+    # Set model to evaluation mode and configure backend settings
+    model.eval()
+    torch.backends.cudnn.enabled = False
+    torch.backends.cuda.matmul.allow_tf32 = False
+    
+    # Get a sample from the data loader
+    _, data = next(enumerate(data_loader))
+
+    # Extract and prepare input data
+    inputs = [t for t in data['img_inputs'][0]]
+    meta = data['img_metas'][0].data
+    seq_group_idx = int(meta[0][0]['sequence_group_idx'])
+    start_seq = meta[0][0]['start_of_sequence']
+    curr_to_prev_ego_rt = torch.stack([meta[0][0]['curr_to_prev_ego_rt']])
+    seq_ids = torch.LongTensor([seq_group_idx])
+    start_of_sequence = torch.BoolTensor([start_seq])
+
+    # Preprocess inputs
+    with torch.no_grad():
+        # Prepare model-specific inputs
+        mlp_input = model.prepare_mlp_inputs(inputs[1:7])
+        ranks_bev, ranks_depth, ranks_feat, interval_starts, interval_lengths = model.prepare_bevpool_inputs(inputs[1:7])
+        (
+            ref_2d, bev_query_depth, reference_points_cam, per_cam_mask_list, indexes, index_len,
+            queries_rebatch, reference_points_rebatch, bev_query_depth_rebatch
+        ) = model.prepare_bwdproj_inputs(inputs[1:7])
+
+        # Generate forward augmentations and history data
+        forward_augs = model.generate_forward_augs(inputs[-1])
+        history_bev = torch.zeros(config.output_shapes['output_history_bev'])
+        history_seq_ids = seq_ids
+        history_forward_augs = forward_augs.clone()
+        history_sweep_time = history_bev.new_zeros(history_bev.shape[0], model.history_cat_num) 
+        start_of_sequence = torch.BoolTensor([True])
+
+        # Prepare the grid
+        grid = model.generate_grid(history_forward_augs, forward_augs, curr_to_prev_ego_rt, config.grid_size, dtype=forward_augs.dtype, device=forward_augs.device)
+
+    inputs_ = dict(
+        imgs=inputs[0].detach().cpu().numpy(),
+        mlp_input=mlp_input.detach().cpu().numpy(), 
+        ranks_depth=ranks_depth.detach().cpu().numpy(), 
+        ranks_feat=ranks_feat.detach().cpu().numpy(),
+        ranks_bev=ranks_bev.detach().cpu().numpy(), 
+        interval_starts=interval_starts.detach().cpu().numpy(), 
+        interval_lengths=interval_lengths.detach().cpu().numpy(), 
+        ref_2d=ref_2d.detach().cpu().numpy(), 
+        bev_query_depth=bev_query_depth.detach().cpu().numpy(),
+        reference_points_cam=reference_points_cam.detach().cpu().numpy(), 
+        per_cam_mask_list=per_cam_mask_list.detach().cpu().numpy(),
+        indexes=indexes.detach().cpu().numpy(), 
+        queries_rebatch=queries_rebatch.detach().cpu().numpy(),
+        reference_points_rebatch=reference_points_rebatch.detach().cpu().numpy(), 
+        bev_query_depth_rebatch=bev_query_depth_rebatch.detach().cpu().numpy(),
+        start_of_sequence=start_of_sequence.detach().cpu().numpy(),
+        grid=grid.detach().cpu().numpy(),
+        history_bev=history_bev.detach().cpu().numpy(),
+        history_seq_ids=history_seq_ids.detach().cpu().numpy().astype(np.int32),
+        history_sweep_time=history_sweep_time.detach().cpu().numpy().astype(np.int32)
+        )
+
+    inputs = {}
+    for key in inputs_.keys():
+        inputs[key] = inputs_[key]
+        if isinstance(inputs_[key], np.ndarray):
+            # save inputs for TRT engine creation
+            inputs_[key].tofile(os.path.join(args.data_dir, key + '.dat'))
+            if key in ['ranks_bev', 'interval_starts', 'indexes']: 
+                np.save(os.path.join(args.data_dir, key + '.npy'), inputs_[key]) # Need numpy to preserve the shape
+            inputs[key] = torch.from_numpy(inputs_[key])
+        if args.cuda: 
+            inputs[key] = inputs[key].cuda()
+        assert isinstance(inputs[key], torch.Tensor) or isinstance(inputs[key][0], torch.Tensor)
+
+    # Prepare input and output names for TensorRT        
+    input_names = list(inputs.keys())
+    inputs = [inputs[key] for key in input_names]
+    output_names=['pred_occupancy', 'output_history_bev', 'output_history_seq_ids', 'output_history_sweep_time']
+
+    if args.cuda:
+        model.cuda()
+
+    # Export the model to ONNX format
+    with torch.no_grad():
+        dynamic_axes = {
+            'ranks_bev': {0: 'ranks_bev_shape_0'},
+            'ranks_depth': {0: 'ranks_depth_shape_0'},
+            'ranks_feat': {0: 'ranks_feat_shape_0'},
+            'interval_starts': {0: 'interval_starts_shape_0'},
+            'interval_lengths': {0: 'interval_lengths_shape_0'},
+            'indexes': {2: 'indexes_shape_0'},
+            'queries_rebatch': {2: 'queries_rebatch_shape_0'},
+            'reference_points_rebatch': {2: 'reference_points_rebatch_shape_0'},
+            'bev_query_depth_rebatch': {2: 'bev_query_depth_rebatch_shape_0'}
+        }
+
+        torch.onnx.export(
+            model=model,
+            args=inputs,
+            f=onnx_path,
+            opset_version=args.opset_version,
+            input_names=input_names,
+            output_names=output_names,
+            operator_export_type=torch.onnx.OperatorExportTypes.ONNX_FALLTHROUGH,
+            export_params=True,
+            do_constant_folding=False,
+            verbose=False,
+            keep_initializers_as_inputs=True,
+            dynamic_axes=dynamic_axes
+        )
+
+    print(f"ONNX model successfully generated and saved at {onnx_path}")
+    convert_Reshape_node_allowzero(onnx_path)
+
+def convert_Reshape_node_allowzero(onnx_path):
+    graph = gs.import_onnx(onnx.load(onnx_path))
+    for node in graph.nodes:
+        if node.op == "Reshape":
+            node.attrs["allowzero"] = 1
+    onnx.save(gs.export_onnx(graph), onnx_path)
+    return graph
+
+if __name__ == "__main__":
+    main()
+

--- a/mmdet3d/models/fbbev/__init__.py
+++ b/mmdet3d/models/fbbev/__init__.py
@@ -3,3 +3,4 @@ from .modules import *
 from .utils import *
 from .view_transformation import *
 from .heads import *
+from .custom_ops import *

--- a/mmdet3d/models/fbbev/custom_ops/__init__.py
+++ b/mmdet3d/models/fbbev/custom_ops/__init__.py
@@ -1,0 +1,3 @@
+from .grid_sampler import grid_sampler
+from .bev_pool_v2 import bev_pool_v2
+from .multi_scale_deformable_attn import multi_scale_deformable_attn

--- a/mmdet3d/models/fbbev/detectors/__init__.py
+++ b/mmdet3d/models/fbbev/detectors/__init__.py
@@ -1,2 +1,3 @@
 
 from .fbocc import FBOCC
+from .fbocc_trt import FBOCCTRT

--- a/mmdet3d/models/fbbev/detectors/fbocc_trt.py
+++ b/mmdet3d/models/fbbev/detectors/fbocc_trt.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2022-2024, NVIDIA Corporation & Affiliates. All rights reserved. 
+# 
+# This work is made available under the Nvidia Source Code License-NC. 
+# To view a copy of this license, visit 
+# https://github.com/NVlabs/FB-BEV/blob/main/LICENSE
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.nn.utils.rnn as rnn_utils
+
+from mmdet.models import DETECTORS
+from mmdet3d.models.fbbev.detectors.fbocc import FBOCC, generate_forward_transformation_matrix
+from mmdet3d.models.fbbev.custom_ops.bev_pool_v2 import bev_pool_v2
+from mmdet3d.models.fbbev.custom_ops.grid_sampler import grid_sampler
+
+@DETECTORS.register_module()
+class FBOCCTRT(FBOCC):
+    def __init__(self, *args, **kwargs):
+        super(FBOCCTRT, self).__init__(*args, **kwargs)      
+        self.num_cams = 6
+
+        self.embed_dims = self.backward_projection.transformer.embed_dims
+        self.pc_range = self.backward_projection.transformer.encoder.pc_range
+        
+        self.bev_pool_v2 = bev_pool_v2
+        self.inverse = torch.linalg.inv
+        self.grid_sample = grid_sampler
+    
+    def prepare_mlp_inputs(self, cam_params):
+        return self.depth_net.get_mlp_input(*cam_params)
+    
+    def generate_forward_augs(self, bda):
+        return generate_forward_transformation_matrix(bda)
+    
+    def prepare_bevpool_inputs(self, cam_params):
+        coor = self.forward_projection.get_lidar_coor(*cam_params)
+        ranks_bev, ranks_depth, ranks_feat, interval_starts, interval_lengths = \
+            self.forward_projection.voxel_pooling_prepare_v2(coor)
+        return ranks_bev, ranks_depth, ranks_feat, interval_starts, interval_lengths
+    
+    def prepare_bwdproj_inputs(self, cam_params, bs=1):
+        ref_2d = self.get_reference_points(self.backward_projection.bev_h, self.backward_projection.bev_w, dim='2d', bs=bs)
+        ref_3d = self.get_reference_points(self.backward_projection.bev_h, self.backward_projection.bev_w, 
+                                           self.pc_range[5]-self.pc_range[2], dim='3d', bs=bs)
+        ref_3d, reference_points_cam, per_cam_mask_list, bev_query_depth = self.point_sampling_trt(ref_3d, cam_params)
+        indexes, index_len, queries_rebatch, reference_points_rebatch, bev_query_depth_rebatch \
+              = self.get_rebatch_tensors_N_indices(per_cam_mask_list, reference_points_cam, bs=bs)
+        
+        return ref_2d, bev_query_depth, reference_points_cam, per_cam_mask_list, indexes, index_len, \
+            queries_rebatch, reference_points_rebatch, bev_query_depth_rebatch
+    
+    def get_rebatch_tensors_N_indices(self, per_cam_mask_list, reference_points_cam, bs=1):
+        indexes = [[] for _ in range(bs)]
+        index_len = torch.zeros(bs, len(per_cam_mask_list))
+
+        for j in range(bs):
+            for i, per_cam_mask in enumerate(per_cam_mask_list):
+                index_query_per_img = per_cam_mask[j].sum(-1).nonzero()
+                index_query_per_img = index_query_per_img[:, 0]
+                if len(index_query_per_img) == 0:
+                    index_query_per_img = per_cam_mask_list[i][j].sum(-1).nonzero()
+                    index_query_per_img = index_query_per_img.view(index_query_per_img.size(0))[0:1]
+                indexes[j].append(index_query_per_img)
+                index_len[j, i] = int(len(index_query_per_img))
+            indexes[j] = rnn_utils.pad_sequence(indexes[j], batch_first=True)
+
+        indexes = torch.cat(indexes, dim=0).view(bs, len(per_cam_mask_list), -1)
+        index_len = index_len.view(bs, -1).to(torch.int32)
+        max_len = index_len.max().to(torch.int32)
+
+        D = reference_points_cam.size(3)
+        queries_rebatch = torch.zeros([bs, self.num_cams, max_len.int(), self.embed_dims])
+        reference_points_rebatch = torch.zeros([bs, self.num_cams, max_len.int(), D, 2])
+        bev_query_depth_rebatch = torch.zeros([bs, self.num_cams, max_len, D, 1])
+        return indexes, index_len, queries_rebatch, reference_points_rebatch, bev_query_depth_rebatch
+    
+    def get_reference_points(self, H, W, Z=8, dim='3d', bs=1, device='cpu', dtype=torch.float):
+        return self.backward_projection.transformer.encoder.get_reference_points(H, W, Z, dim, bs, device, dtype)
+        
+    def point_sampling_trt(self, reference_points, cam_params):
+        return self.backward_projection.transformer.encoder.point_sampling(
+            reference_points, pc_range=None, img_metas=None, cam_params=cam_params)
+    
+    def forward_trt(self, inputs):
+        imgs, mlp_input, ranks_depth, ranks_feat, ranks_bev, interval_starts, interval_lengths, \
+            ref_2d, bev_query_depth, reference_points_cam, per_cam_mask_list, indexes, \
+                queries_rebatch, reference_points_rebatch, bev_query_depth_rebatch, \
+                start_of_sequence, grid, history_bev, history_seq_ids, history_sweep_time = inputs
+        
+        # image encoder
+        x = self.image_encoder(imgs) 
+        feat, depth = self.depth_net(x, mlp_input) 
+        
+        # forward projection
+        bev_feat = self.bev_pool_v2(depth, 
+                                    feat.permute(0, 1, 3, 4, 2), 
+                                    ranks_depth, 
+                                    ranks_feat, 
+                                    ranks_bev,  
+                                    interval_starts, 
+                                    interval_lengths).permute(0, 4, 2, 3, 1)
+                
+        # backward_projection
+        bev_feat_refined = self.backward_projection_trt(feat,
+                                    [ref_2d, bev_query_depth, reference_points_cam, per_cam_mask_list, indexes, \
+                                     queries_rebatch, reference_points_rebatch, bev_query_depth_rebatch],
+                                    lss_bev=bev_feat.mean(-1),
+                                    bev_mask=None,
+                                    gt_bboxes_3d=None, 
+                                    pred_img_depth=depth)  
+        bev_feat = bev_feat_refined[..., None] + bev_feat 
+        
+        # Fuse History
+        bev_feat, output_history_bev, output_history_seq_ids, output_history_sweep_time = self.fuse_history_trt(bev_feat, 
+                                         start_of_sequence, 
+                                         history_bev, 
+                                         history_sweep_time, 
+                                         history_seq_ids,
+                                         grid) 
+        
+        bev_feat = self.bev_encoder(bev_feat) 
+        pred_occupancy = self.occupancy_head(bev_feat, results={})['output_voxels'][0] 
+        
+        return pred_occupancy, output_history_bev, output_history_seq_ids, output_history_sweep_time
+    
+    def fuse_history_trt(self, 
+                         curr_bev, 
+                         start_of_sequence, 
+                         history_bev, 
+                         history_sweep_time, 
+                         history_seq_ids,
+                         grid
+                         ):
+        curr_bev = curr_bev.permute(0, 1, 4, 2, 3)
+        n, c_, z, h, w = curr_bev.shape 
+        
+        history_bev = history_bev.to(curr_bev)
+        tmp_bev = start_of_sequence.float() * curr_bev.repeat(1, self.history_cat_num, 1, 1, 1) + (1. - start_of_sequence.float()) * history_bev
+        n, mc, z, h, w = tmp_bev.shape
+        tmp_bev = tmp_bev.reshape(n, mc, z, h, w)
+        sampled_history_bev = self.grid_sample(tmp_bev, 10. * grid.to(curr_bev.dtype).permute(0, 4, 3, 1, 2), align_corners=True, interpolation_mode=self.interpolation_mode, padding_mode='zeros')
+        
+        ## Update history
+        # Add in current frame to features & timestep
+        history_sweep_time = torch.cat([history_sweep_time.new_zeros(history_sweep_time.shape[0], 1), history_sweep_time], dim=1) # B x (1 + T)
+            
+        sampled_history_bev = sampled_history_bev.reshape(n, mc, z, h, w)
+        curr_bev = curr_bev.reshape(n, c_, z, h, w)
+        feats_cat = torch.cat([curr_bev, sampled_history_bev], dim=1)
+
+        # Reshape and concatenate features and timestep
+        feats_to_return = feats_cat.reshape(feats_cat.shape[0], self.history_cat_num + 1, self.single_bev_num_channels, *feats_cat.shape[2:]) # B x (1 + T) x 80 x H x W
+        
+        feats_to_return = torch.cat(
+        [feats_to_return, history_sweep_time[:, :, None, None, None, None].repeat(
+            1, 1, 1, *feats_to_return.shape[3:]) * self.history_cam_sweep_freq
+        ], dim=2) 
+
+        # Time conv
+        B, Tplus1, C, Z, H, W = feats_to_return.shape
+        feats_to_return = self.history_keyframe_time_conv(feats_to_return.reshape(B*Tplus1, C, Z, H, W))
+        feats_to_return = feats_to_return.reshape(B, Tplus1, 80, Z, H, W) 
+        
+        # Cat keyframes & conv
+        B, Tplus1, C, Z, H, W = feats_to_return.shape  
+        feats_to_return = feats_to_return.reshape(B, Tplus1*C, Z, H, W)
+        feats_to_return = self.history_keyframe_cat_conv(feats_to_return) 
+        
+        history_bev = feats_cat[:, :-self.single_bev_num_channels, ...].detach().clone()
+        history_sweep_time = history_sweep_time[:, :-1]
+
+        feats_to_return = feats_to_return.permute(0, 1, 3, 4, 2)
+
+        return feats_to_return.clone(), history_bev, history_seq_ids, history_sweep_time
+
+    def backward_projection_trt(self, feat, bev_info, lss_bev=None, gt_bboxes_3d=None, pred_img_depth=None, bev_mask=None):
+        bs, num_cam, c, h, w = feat.shape
+        dtype = feat.dtype
+        bev_queries = self.backward_projection.bev_embedding.weight.to(dtype)
+        bev_queries = bev_queries.unsqueeze(1)
+        
+        lss_bev = lss_bev.flatten(2).permute(2, 0, 1)
+        bev_queries = bev_queries + lss_bev
+        
+        bev_pos = self.backward_projection.positional_encoding(bs, self.backward_projection.bev_h, self.backward_projection.bev_w, bev_queries.device).to(dtype)
+        bev_pos = bev_pos.flatten(2).permute(2, 0, 1)
+        
+        spatial_shapes = [(h, w)]
+        feat_flatten = feat.flatten(3).permute(1, 0, 3, 2)
+
+        spatial_shapes = torch.as_tensor(spatial_shapes, dtype=torch.long, device=bev_pos.device)
+        level_start_index = torch.cat((spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1]))
+
+        feat_flatten = feat_flatten.permute(0, 2, 1, 3)  
+        
+        bev_embed = self.back_proj_transformer_encoder_trt(
+            bev_queries,
+            feat_flatten,
+            feat_flatten,
+            bev_info,
+            bev_h=self.backward_projection.bev_h,
+            bev_w=self.backward_projection.bev_w,
+            bev_pos=bev_pos,
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+            gt_bboxes_3d=gt_bboxes_3d,
+            pred_img_depth=pred_img_depth,
+            prev_bev=None,
+            bev_mask=bev_mask
+        )
+        bev_embed = bev_embed.permute(0, 2, 1).view(bs, 
+                                                    -1, 
+                                                    self.backward_projection.bev_h, 
+                                                    self.backward_projection.bev_w).contiguous()
+        return bev_embed
+
+    def back_proj_transformer_encoder_trt(self, 
+                                          bev_query,
+                                          key,
+                                          value,
+                                          bev_info,
+                                          *args,
+                                          bev_h=None,
+                                          bev_w=None,
+                                          bev_pos=None,
+                                          spatial_shapes=None,
+                                          level_start_index=None,
+                                          valid_ratios=None,
+                                          gt_bboxes_3d=None,
+                                          pred_img_depth=None,
+                                          bev_mask=None,
+                                          prev_bev=None,
+                                          **kwargs):   
+        output = bev_query
+        intermediate = []
+        ref_2d, bev_query_depth, reference_points_cam, per_cam_mask_list, indexes, \
+            queries_rebatch, reference_points_rebatch, bev_query_depth_rebatch = bev_info
+        bev_query = bev_query.permute(1, 0, 2)
+        bev_pos = bev_pos.permute(1, 0, 2)
+                
+        for lid, layer in enumerate(self.backward_projection.transformer.encoder.layers):
+            output = layer(
+                bev_query,
+                key,
+                value,
+                *args,
+                bev_pos=bev_pos,
+                ref_2d=ref_2d,
+                ref_3d=None,
+                bev_h=self.backward_projection.bev_h,
+                bev_w=self.backward_projection.bev_w,
+                prev_bev=prev_bev,
+                spatial_shapes=spatial_shapes,
+                level_start_index=level_start_index,
+                reference_points_cam=reference_points_cam,
+                per_cam_mask_list=per_cam_mask_list,
+                bev_mask=bev_mask,
+                bev_query_depth=bev_query_depth,
+                pred_img_depth=pred_img_depth,
+                indexes=indexes,  
+                queries_rebatch=queries_rebatch,
+                reference_points_rebatch=reference_points_rebatch,
+                bev_query_depth_rebatch=bev_query_depth_rebatch,
+                **kwargs)
+
+            bev_query = output
+            if self.backward_projection.transformer.encoder.return_intermediate:
+                intermediate.append(output)
+
+        if self.backward_projection.transformer.encoder.return_intermediate:
+            return torch.stack(intermediate)
+        return output
+    
+    def post_process(self, pred_occupancy):
+        pred_occupancy = pred_occupancy.permute(0, 2, 3, 4, 1)[0]
+        pred_occupancy = pred_occupancy[..., 1:]     
+        pred_occupancy = pred_occupancy.softmax(-1)
+
+        # convert to CVPR2023 Format
+        pred_occupancy = pred_occupancy.permute(3, 2, 0, 1)
+        pred_occupancy = torch.flip(pred_occupancy, [2])
+        pred_occupancy = torch.rot90(pred_occupancy, -1, [2, 3])
+        pred_occupancy = pred_occupancy.permute(2, 3, 1, 0)
+        
+        pred_occupancy_category = pred_occupancy.argmax(-1) 
+        
+        pred_occupancy_category= pred_occupancy_category.cpu().numpy()
+        
+        result_dict = {}
+        result_dict['pts_bbox'] = None
+        result_dict['iou'] = None
+        result_dict['pred_occupancy'] = pred_occupancy_category
+        result_dict['index'] = None
+        return [result_dict]
+    

--- a/mmdet3d/models/fbbev/view_transformation/backward_projection/__init__.py
+++ b/mmdet3d/models/fbbev/view_transformation/backward_projection/__init__.py
@@ -1,3 +1,3 @@
-from .backward_projection import BackwardProjection
+from .backward_projection import BackwardProjection, BackwardProjectionTRT
 from .bevformer_utils import *
 

--- a/mmdet3d/models/fbbev/view_transformation/backward_projection/bevformer_utils/__init__.py
+++ b/mmdet3d/models/fbbev/view_transformation/backward_projection/bevformer_utils/__init__.py
@@ -1,4 +1,5 @@
 from .bevformer import BEVFormer
 from .bevformer_encoder import bevformer_encoder, BEVFormerEncoderLayer
-from .spatial_cross_attention_depth import DA_MSDeformableAttention, DA_SpatialCrossAttention
+from .spatial_cross_attention_depth import DA_MSDeformableAttention, DA_SpatialCrossAttention, DA_MSDeformableAttentionTRT, DA_SpatialCrossAttentionTRT
 from .positional_encoding import CustormLearnedPositionalEncoding
+from .multi_scale_deformable_attn_function import MultiScaleDeformableAttentionTRT

--- a/mmdet3d/models/fbbev/view_transformation/backward_projection/bevformer_utils/spatial_cross_attention_depth.py
+++ b/mmdet3d/models/fbbev/view_transformation/backward_projection/bevformer_utils/spatial_cross_attention_depth.py
@@ -25,6 +25,7 @@ from .multi_scale_deformable_attn_function import MultiScaleDeformableAttnFuncti
 ext_module = ext_loader.load_ext(
     '_ext', ['ms_deform_attn_backward', 'ms_deform_attn_forward'])
 
+from mmdet3d.models.fbbev.custom_ops.multi_scale_deformable_attn import multi_scale_deformable_attn
 
 
 @ATTENTION.register_module()
@@ -222,6 +223,139 @@ class DA_SpatialCrossAttention(BaseModule):
             return  self.dropout(self.layer_scale * slots) +  inp_residual
 
 
+@ATTENTION.register_module()
+class DA_SpatialCrossAttentionTRT(DA_SpatialCrossAttention):    
+    @force_fp32(apply_to=('query', 'key', 'value', 'query_pos', 'reference_points_cam'))
+    def forward(self,
+                query,
+                key,
+                value,
+                residual=None,
+                query_pos=None,
+                key_padding_mask=None,
+                reference_points=None,
+                spatial_shapes=None,
+                reference_points_cam=None,
+                level_start_index=None,
+                flag='encoder',
+                bev_query_depth=None,
+                pred_img_depth=None,
+                bev_mask=None,
+                per_cam_mask_list=None,
+                indexes=None, 
+                queries_rebatch=None,
+                reference_points_rebatch=None,
+                bev_query_depth_rebatch=None,
+                **kwargs):
+        """Forward Function of Detr3DCrossAtten.
+        Args:
+            query (Tensor): Query of Transformer with shape
+                (num_query, bs, embed_dims).
+            key (Tensor): The key tensor with shape
+                `(num_key, bs, embed_dims)`.
+            value (Tensor): The value tensor with shape
+                `(num_key, bs, embed_dims)`. (B, N, C, H, W)
+            residual (Tensor): The tensor used for addition, with the
+                same shape as `x`. Default None. If None, `x` will be used.
+            query_pos (Tensor): The positional encoding for `query`.
+                Default: None.
+            key_pos (Tensor): The positional encoding for  `key`. Default
+                None.
+            reference_points (Tensor):  The normalized reference
+                points with shape (bs, num_query, 4),
+                all elements is range in [0, 1], top-left (0,0),
+                bottom-right (1, 1), including padding area.
+                or (N, Length_{query}, num_levels, 4), add
+                additional two dimensions is (w, h) to
+                form reference boxes.
+            key_padding_mask (Tensor): ByteTensor for `query`, with
+                shape [bs, num_key].
+            spatial_shapes (Tensor): Spatial shape of features in
+                different level. With shape  (num_levels, 2),
+                last dimension represent (h, w).
+            level_start_index (Tensor): The start index of each level.
+                A tensor has shape (num_levels) and can be represented
+                as [0, h_0*w_0, h_0*w_0+h_1*w_1, ...].
+        Returns:
+             Tensor: forwarded results with shape [num_query, bs, embed_dims].
+        """
+
+        N, B, len_query, Z, _ = bev_query_depth.shape
+        B, N, DC, H, W = pred_img_depth.shape
+        bev_query_depth = bev_query_depth.permute(1, 0, 2, 3, 4) 
+        pred_img_depth = pred_img_depth.view(B*N, DC, H, W)
+        pred_img_depth = pred_img_depth.flatten(2).permute(0, 2, 1)
+
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+
+        if residual is None:
+            inp_residual = query
+            slots = torch.zeros_like(query)
+        if query_pos is not None:
+            query = query + query_pos
+        
+        bs, num_query, _ = query.size()
+        D = reference_points_cam.size(3)
+
+        
+
+        if bev_mask is not None:
+            per_cam_mask_list_ = per_cam_mask_list & bev_mask[None, :, :, None]
+        else:
+            per_cam_mask_list_ = per_cam_mask_list
+            
+        max_len = indexes.size(2) 
+        
+        for j in range(bs):
+            for i, reference_points_per_img in enumerate(reference_points_cam):   
+                index_query_per_img = indexes[j, i, indexes[j, i].nonzero()][:, 0]
+                dims = torch.arange(index_query_per_img.shape[0])
+                queries_rebatch[j, i, dims, :] = query[j, index_query_per_img, :]
+                bev_query_depth_rebatch[j, i, dims, :, :] = bev_query_depth[j, i, index_query_per_img, :, :]
+                reference_points_rebatch[j, i, dims, :, :] = reference_points_per_img[j, index_query_per_img, :, :]
+
+        num_cams, l, bs, embed_dims = key.shape
+
+        key = key.permute(2, 0, 1, 3).reshape(
+            bs * self.num_cams, l, self.embed_dims)
+        value = value.permute(2, 0, 1, 3).reshape(
+            bs * self.num_cams, l, self.embed_dims)
+
+        bev_query_depth_rebatch = (bev_query_depth_rebatch - self.dbound[0]) / self.dbound[2]
+        bev_query_depth_rebatch = torch.clip(torch.floor(bev_query_depth_rebatch), 0, DC-1).to(torch.long)
+        bev_query_depth_rebatch = bev_query_depth_rebatch.view(bev_query_depth_rebatch.size(0),
+                                                               bev_query_depth_rebatch.size(1),
+                                                               bev_query_depth_rebatch.size(2),
+                                                               bev_query_depth_rebatch.size(3))
+        bev_query_depth_rebatch = F.one_hot(bev_query_depth_rebatch, num_classes=DC)        
+                                   
+        queries = self.deformable_attention(query=queries_rebatch.view(bs*self.num_cams, max_len, self.embed_dims), key=key, value=value,\
+                                            reference_points=reference_points_rebatch.view(bs*self.num_cams, max_len, D, 2), spatial_shapes=spatial_shapes,\
+                                            level_start_index=level_start_index,\
+                                            bev_query_depth=bev_query_depth_rebatch.view(bs*self.num_cams, max_len, D, DC),\
+                                            pred_img_depth=pred_img_depth, \
+                                            ).view(bs, self.num_cams, max_len, self.embed_dims)
+
+        bs, num_cams, max_len, feature_dim = queries.size()
+        
+        for j in range(bs):
+            for i, per_cam_mask in enumerate(per_cam_mask_list_):
+                index_query_per_img = indexes[j, i, indexes[j, i].nonzero()][:, 0]
+                dims = torch.arange(index_query_per_img.shape[0])
+                slots[j, index_query_per_img, :] += queries[j, i, dims, :]
+
+        count = per_cam_mask_list_.sum(-1) > 0
+        count = count.permute(1, 2, 0).sum(-1)
+        count = torch.clamp(count, min=1.0)
+        slots = slots / count[..., None]
+        slots = self.output_proj(slots)
+        if self.layer_scale is None:
+            return self.dropout(slots) + inp_residual
+        else:
+            return  self.dropout(self.layer_scale * slots) +  inp_residual
 
 
 @ATTENTION.register_module()
@@ -464,4 +598,131 @@ class DA_MSDeformableAttention(BaseModule):
                 value, spatial_shapes, sampling_locations, attention_weights)
         if not self.batch_first:
             output = output.permute(1, 0, 2)
+        return output
+
+@ATTENTION.register_module()
+class DA_MSDeformableAttentionTRT(DA_MSDeformableAttention): 
+    def __init__(self,
+                 embed_dims=256,
+                 num_heads=8,
+                 num_levels=4,
+                 num_points=8,
+                 num_Z_anchors=4,
+                 im2col_step=64,
+                 dropout=0.1,
+                 batch_first=True,
+                 disable_deformable=False,
+                 norm_cfg=None,
+                 init_cfg=None):
+        super(DA_MSDeformableAttentionTRT, self).__init__(embed_dims,
+                                                          num_heads,
+                                                          num_levels,
+                                                          num_points,
+                                                          num_Z_anchors,
+                                                          im2col_step,
+                                                          dropout,
+                                                          batch_first,
+                                                          disable_deformable,
+                                                          norm_cfg,
+                                                          init_cfg)
+        self.multi_scale_deformable_attn = multi_scale_deformable_attn
+        self.init_weights()
+    @force_fp32()
+    def forward(self,
+                query,
+                key=None,
+                value=None,
+                identity=None,
+                query_pos=None,
+                key_padding_mask=None,
+                reference_points=None,
+                spatial_shapes=None,
+                level_start_index=None,
+                bev_query_depth=None,
+                pred_img_depth=None,
+               
+                **kwargs):
+        if value is None:
+            value = query
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+
+        if not self.batch_first:
+            # change to (bs, num_query ,embed_dims)
+            query = query.permute(1, 0, 2)
+            value = value.permute(1, 0, 2)
+        
+        bs, num_query, _ = query.shape
+        bs, num_value, _ = value.shape
+        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
+
+        value = self.value_proj(value)
+        if key_padding_mask is not None:
+            value = value.masked_fill(key_padding_mask[..., None], 0.0)
+        value = value.view(bs, num_value, self.num_heads, -1)
+        sampling_offsets = self.sampling_offsets(query).view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points, 2)
+        attention_weights = self.attention_weights(query).view(
+            bs, num_query, self.num_heads, self.num_levels * self.num_points)
+        
+        if self.disable_deformable:
+            sampling_offsets = sampling_offsets * 0
+            attention_weights = attention_weights * 0
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(bs, num_query,
+                                                   self.num_heads,
+                                                   self.num_levels,
+                                                   self.num_points)
+            
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = torch.stack(
+                [spatial_shapes[..., 1], spatial_shapes[..., 0]], -1)
+
+            bs, num_query, num_Z_anchors, xy = reference_points.shape
+            reference_points = reference_points[:, :, None, None, None, :, :]
+
+            sampling_offsets = sampling_offsets / \
+                offset_normalizer[None, None, None, :, None, :]
+            bs, num_query, num_heads, num_levels, num_all_points, xy = sampling_offsets.shape
+            sampling_offsets = sampling_offsets.view(bs, num_query, num_heads, num_levels, num_all_points // num_Z_anchors, num_Z_anchors, xy)
+            
+            sampling_locations = reference_points + sampling_offsets
+            bs, num_query, num_heads, num_levels, num_points, num_Z_anchors, xy = sampling_locations.shape
+            assert num_all_points == num_points * num_Z_anchors
+            
+            sampling_locations = sampling_locations.view(
+                bs, num_query, num_heads, num_levels, num_all_points, xy)
+        elif reference_points.shape[-1] == 4:
+            assert False
+        else:
+            raise ValueError(
+                f'Last dim of reference_points must be'
+                f' 2 or 4, but get {reference_points.shape[-1]} instead.')
+        
+        depth_reference_points = reference_points.reshape(bs, num_query * num_Z_anchors, 1, 1, 1, 2).contiguous()
+        depth_attention_weights = torch.ones_like(depth_reference_points[...,0]).contiguous()
+        
+        depth_weights = self.multi_scale_deformable_attn(pred_img_depth.unsqueeze(2).contiguous(), 
+                                                               spatial_shapes[0:1], 
+                                                               level_start_index[0:1], 
+                                                               depth_reference_points,
+                                                               depth_attention_weights).reshape(bs, num_query, num_Z_anchors, -1)
+                
+        depth_weights = (depth_weights * bev_query_depth).sum(-1)
+        depth_weights = depth_weights.unsqueeze(2).repeat(1,1, num_points, 1).reshape(bs, num_query, num_all_points)
+        
+        attention_weights = attention_weights * depth_weights[:, :, None, None, :]
+        
+        output = self.multi_scale_deformable_attn(value, 
+                                                  spatial_shapes, 
+                                                  level_start_index, 
+                                                  sampling_locations, 
+                                                  attention_weights).view(value.shape[0], attention_weights.shape[1], value.shape[2] * value.shape[3])
+        
+        if not self.batch_first:
+            output = output.permute(1, 0, 2)
+        
         return output

--- a/mmdet3d/models/fbbev/view_transformation/forward_projection/__init__.py
+++ b/mmdet3d/models/fbbev/view_transformation/forward_projection/__init__.py
@@ -1,1 +1,1 @@
-from .view_transformer import LSSViewTransformerFunction, LSSViewTransformerFunction3D
+from .view_transformer import LSSViewTransformerFunction, LSSViewTransformerFunction3D, LSSViewTransformerFunction3DTRT

--- a/occupancy_configs/fb_occ/fbocc-r50-cbgs_depth_16f_16x4_20e_trt.py
+++ b/occupancy_configs/fb_occ/fbocc-r50-cbgs_depth_16f_16x4_20e_trt.py
@@ -1,0 +1,398 @@
+# Copyright (c) 2022-2024, NVIDIA Corporation & Affiliates. All rights reserved. 
+# 
+# This work is made available under the Nvidia Source Code License-NC. 
+# To view a copy of this license, visit 
+# https://github.com/NVlabs/FB-BEV/blob/main/LICENSE
+
+
+# we follow the online training settings  from solofusion
+num_gpus = 1
+samples_per_gpu = 1
+num_iters_per_epoch = int(28130 // (num_gpus * samples_per_gpu) * 4.554)
+num_epochs = 20
+checkpoint_epoch_interval = 1
+use_custom_eval_hook=True
+
+# Each nuScenes sequence is ~40 keyframes long. Our training procedure samples
+# sequences first, then loads frames from the sampled sequence in order 
+# starting from the first frame. This reduces training step-to-step diversity,
+# lowering performance. To increase diversity, we split each training sequence
+# in half to ~20 keyframes, and sample these shorter sequences during training.
+# During testing, we do not do this splitting.
+train_sequences_split_num = 2
+test_sequences_split_num = 1
+
+# By default, 3D detection datasets randomly choose another sample if there is
+# no GT object in the current sample. This does not make sense when doing
+# sequential sampling of frames, so we disable it.
+filter_empty_gt = False
+
+# Long-Term Fusion Parameters
+do_history = False
+history_cat_num = 16
+history_cat_conv_out_channels = 160
+
+
+# Copyright (c) Phigent Robotics. All rights reserved.
+
+_base_ = ['../../occupancy_configs/_base_/datasets/nus-3d.py', '../../occupancy_configs/_base_/default_runtime.py']
+# Global
+# If point cloud range is changed, the models should also change their point
+# cloud range accordingly
+point_cloud_range = [-40, -40, -1.0, 40, 40, 5.4]
+# For nuScenes we usually do 10-class detection
+class_names = [
+    'car', 'truck', 'construction_vehicle', 'bus', 'trailer', 'barrier',
+    'motorcycle', 'bicycle', 'pedestrian', 'traffic_cone'
+]
+
+data_config = {
+    'cams': [
+        'CAM_FRONT_LEFT', 'CAM_FRONT', 'CAM_FRONT_RIGHT', 'CAM_BACK_LEFT',
+        'CAM_BACK', 'CAM_BACK_RIGHT'
+    ],
+    'Ncams':
+    6,
+    'input_size': (256, 704),
+    'src_size': (900, 1600),
+
+    # Augmentation
+    'resize': (-0.06, 0.11),
+    'rot': (-5.4, 5.4),
+    'flip': True,
+    'crop_h': (0.0, 0.0),
+    'resize_test': 0.00,
+}
+
+bda_aug_conf = dict(
+    rot_lim=(-22.5, 22.5),
+    scale_lim=(1., 1.),
+    flip_dx_ratio=0.5,
+    flip_dy_ratio=0.5)
+
+use_checkpoint = False
+sync_bn = False
+
+
+# Model
+grid_config = {
+    'x': [-40, 40, 0.8],
+    'y': [-40, 40, 0.8],
+    'z': [-1, 5.4, 0.8],
+    'depth': [2.0, 42.0, 0.5],
+}      
+depth_categories = 80 #(grid_config['depth'][1]-grid_config['depth'][0])//grid_config['depth'][2]
+grid_size = (1, 80, 8, 100, 100)
+## config for bevformer
+grid_config_bevformer={
+        'x': [-40, 40, 0.8],
+        'y': [-40, 40, 0.8],
+        'z': [-1, 5.4, 1.6],
+       }
+bev_h_ = 100
+bev_w_ = 100
+numC_Trans=80
+_dim_ = 256
+_pos_dim_ = 40
+_ffn_dim_ = numC_Trans * 4
+_num_levels_= 1
+
+empty_idx = 18  # noise 0-->255
+num_cls = 19  # 0 others, 1-16 obj, 17 free
+fix_void = num_cls == 19
+img_norm_cfg = None
+
+occ_size = [200, 200, 16]
+voxel_out_indices = (0, 1, 2)
+voxel_out_channel = 256
+voxel_channels = [64, 64*2, 64*4]
+
+
+model = dict(
+    type='FBOCCTRT',
+    use_depth_supervision=True,
+    fix_void=fix_void,
+    do_history = do_history,
+    history_cat_num=history_cat_num,
+    single_bev_num_channels=numC_Trans,
+    readd=True,
+    img_backbone=dict(
+        pretrained='ckpts/r50_256x705_depth_pretrain.pth',
+        type='ResNet',
+        depth=50,
+        num_stages=4,
+        out_indices=(2, 3),
+        frozen_stages=-1,
+        norm_cfg=dict(type='BN', requires_grad=True),
+        norm_eval=False,
+        with_cp=use_checkpoint,
+        style='pytorch'),
+    img_neck=dict(
+        type='CustomFPN',
+        in_channels=[1024, 2048],
+        out_channels=_dim_,
+        num_outs=1,
+        start_level=0,
+        with_cp=use_checkpoint,
+        out_ids=[0]),
+    depth_net=dict(
+        type='CM_DepthNet', # camera-aware depth net
+        in_channels=_dim_,
+        context_channels=numC_Trans,
+        downsample=16,
+        grid_config=grid_config,
+        depth_channels=depth_categories,
+        with_cp=use_checkpoint,
+        loss_depth_weight=1.,
+        use_dcn=False,
+    ),
+    forward_projection=dict(
+        type='LSSViewTransformerFunction3D',
+        grid_config=grid_config,
+        input_size=data_config['input_size'],
+        downsample=16),
+    frpn=None,
+    backward_projection=dict(
+        type='BackwardProjectionTRT',
+        bev_h=bev_h_,
+        bev_w=bev_w_,
+        in_channels=numC_Trans,
+        out_channels=numC_Trans,
+        pc_range=point_cloud_range,
+        transformer=dict(
+            type='BEVFormer',
+            use_cams_embeds=False,
+            embed_dims=numC_Trans,
+            encoder=dict(
+                type='bevformer_encoder',
+                num_layers=1,
+                pc_range=point_cloud_range,
+                grid_config=grid_config_bevformer,
+                data_config=data_config,
+                return_intermediate=False,
+                transformerlayers=dict(
+                    type='BEVFormerEncoderLayer',
+                    attn_cfgs=[
+                        dict(
+                            type='MultiScaleDeformableAttentionTRT',
+                            embed_dims=numC_Trans,
+                            dropout=0.0,
+                            num_levels=1),
+                        dict(
+                            type='DA_SpatialCrossAttentionTRT',
+                            pc_range=point_cloud_range,
+                            dbound=[2.0, 42.0, 0.5],
+                            dropout=0.0,
+                            deformable_attention=dict(
+                                type='DA_MSDeformableAttentionTRT',
+                                embed_dims=numC_Trans,
+                                num_points=8,
+                                num_levels=_num_levels_),
+                            embed_dims=numC_Trans,
+                        )
+                    ],
+                    ffn_cfgs=dict(
+                        type='FFN',
+                        embed_dims=numC_Trans,
+                        feedforward_channels=_ffn_dim_,
+                        ffn_drop=0.0,
+                        act_cfg=dict(type='ReLU', inplace=True),),
+                    feedforward_channels=_ffn_dim_,
+                    ffn_dropout=0.0,
+                    operation_order=('self_attn', 'norm', 'cross_attn', 'norm',
+                                     'ffn', 'norm'))),
+                    # operation_order=('cross_attn', 'norm', 'ffn', 'norm'))),
+                    # operation_order=('cross_attn', 'norm'))),
+           ),
+        positional_encoding=dict(
+            type='CustormLearnedPositionalEncoding',
+            num_feats=_pos_dim_,
+            row_num_embed=bev_h_,
+            col_num_embed=bev_w_,
+            ),
+    ),
+    img_bev_encoder_backbone=dict(
+        type='CustomResNet3D',
+        depth=18,
+        with_cp=False,
+        block_strides=[1, 2, 2],
+        n_input_channels=numC_Trans,
+        block_inplanes=voxel_channels,
+        out_indices=voxel_out_indices,
+        norm_cfg=dict(type='BN3d', requires_grad=True),
+    ),
+    img_bev_encoder_neck=dict(
+        type='FPN3D',
+        with_cp=False,
+        in_channels=voxel_channels,
+        out_channels=voxel_out_channel,
+        norm_cfg=dict(type='BN3d', requires_grad=True),
+    ),
+    occupancy_head= dict(
+        type='OccHead',
+        with_cp=False,
+        use_focal_loss=True,
+        norm_cfg=dict(type='BN3d', requires_grad=True),
+        soft_weights=True,
+        final_occ_size=occ_size,
+        empty_idx=empty_idx,
+        num_level=len(voxel_out_indices),
+        in_channels=[voxel_out_channel] * len(voxel_out_indices),
+        out_channel=num_cls,
+        point_cloud_range=point_cloud_range,
+        loss_weight_cfg=dict(
+            loss_voxel_ce_weight=1.0,
+            loss_voxel_sem_scal_weight=1.0,
+            loss_voxel_geo_scal_weight=1.0,
+            loss_voxel_lovasz_weight=1.0,
+        ),
+    ),
+    pts_bbox_head=None)
+
+# Data
+dataset_type = 'NuScenesDataset'
+data_root = 'data/nuscenes/'
+file_client_args = dict(backend='disk')
+occupancy_path = 'data/nuscenes/gts'
+
+
+train_pipeline = [
+    dict(
+        type='PrepareImageInputs',
+        is_train=True,
+        data_config=data_config),
+    dict(
+        type='LoadAnnotationsBEVDepth',
+        bda_aug_conf=bda_aug_conf,
+        classes=class_names),
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=5,
+        use_dim=5,
+        file_client_args=file_client_args),
+    dict(type='PointToMultiViewDepth', downsample=1, grid_config=grid_config),
+    dict(type='ObjectRangeFilter', point_cloud_range=point_cloud_range),
+    dict(type='ObjectNameFilter', classes=class_names),
+    dict(type='LoadOccupancy', ignore_nonvisible=True, fix_void=fix_void, occupancy_path=occupancy_path),
+    dict(type='DefaultFormatBundle3D', class_names=class_names),
+    dict(
+        type='Collect3D', keys=['img_inputs', 'gt_bboxes_3d', 'gt_labels_3d',  'gt_occupancy', 'gt_depth'
+                               ])
+]
+
+test_pipeline = [
+    dict(
+        type='CustomDistMultiScaleFlipAug3D',
+        tta=False,
+        transforms=[
+            dict(type='PrepareImageInputs', data_config=data_config),
+            dict(
+                type='LoadAnnotationsBEVDepth',
+                bda_aug_conf=bda_aug_conf,
+                classes=class_names,
+                is_train=False),
+            dict(
+                type='LoadPointsFromFile',
+                coord_type='LIDAR',
+                load_dim=5,
+                use_dim=5,
+                file_client_args=file_client_args),
+            dict(type='LoadOccupancy',  occupancy_path=occupancy_path),
+            dict(
+                type='DefaultFormatBundle3D',
+                class_names=class_names,
+                with_label=False),
+            dict(type='Collect3D', keys=['points', 'img_inputs',  'gt_occupancy', 'visible_mask'])
+            ]
+        )
+]
+
+input_modality = dict(
+    use_lidar=False,
+    use_camera=True,
+    use_radar=False,
+    use_map=False,
+    use_external=False)
+
+share_data_config = dict(
+    type=dataset_type,
+    classes=class_names,
+    modality=input_modality,
+    img_info_prototype='bevdet',
+    occupancy_path=occupancy_path,
+    use_sequence_group_flag=True,
+)
+test_data_config = dict(
+    pipeline=test_pipeline,
+    sequences_split_num=test_sequences_split_num,
+    ann_file=data_root + 'bevdetv2-nuscenes_infos_val.pkl')
+
+data = dict(
+    samples_per_gpu=samples_per_gpu,
+    workers_per_gpu=6,
+    test_dataloader=dict(runner_type='IterBasedRunnerEval'),
+    train=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file=data_root + 'bevdetv2-nuscenes_infos_train.pkl',
+        classes=class_names,
+        test_mode=False,
+        use_valid_flag=True,
+        modality=input_modality,
+        img_info_prototype='bevdet',
+        sequences_split_num=train_sequences_split_num,
+        use_sequence_group_flag=True,
+        filter_empty_gt=filter_empty_gt,
+        # we use box_type_3d='LiDAR' in kitti and nuscenes dataset
+        # and box_type_3d='Depth' in sunrgbd and scannet dataset.
+        box_type_3d='LiDAR'),
+    val=test_data_config,
+    test=test_data_config)
+
+for key in ['val', 'test']:
+    data[key].update(share_data_config)
+
+# Optimizer
+lr = 2e-4
+optimizer = dict(type='AdamW', lr=lr, weight_decay=1e-2)
+ 
+optimizer_config = dict(grad_clip=dict(max_norm=5, norm_type=2))
+lr_config = dict(
+    policy='step',
+    warmup='linear',
+    warmup_iters=200,
+    warmup_ratio=0.001,
+    step=[num_iters_per_epoch*num_epochs,])
+runner = dict(type='IterBasedRunner', max_iters=num_epochs * num_iters_per_epoch)
+checkpoint_config = dict(
+    interval=checkpoint_epoch_interval * num_iters_per_epoch)
+evaluation = dict(
+    interval=20 * num_iters_per_epoch, pipeline=test_pipeline)
+
+
+log_config = dict(
+    interval=50,
+    hooks=[
+        dict(type='TextLoggerHook'),
+    ])
+custom_hooks = [
+    dict(
+        type='MEGVIIEMAHook',
+        init_updates=10560,
+        priority='NORMAL',
+        interval=2*num_iters_per_epoch,
+    ),
+    dict(
+        type='SequentialControlHook',
+        temporal_start_iter=num_iters_per_epoch *2,
+    ),
+]
+load_from = 'ckpts/r50_256x705_depth_pretrain.pth'
+fp16 = dict(loss_scale='dynamic')
+
+output_shapes = dict(
+                output_history_bev=[1, 1280, 8, 100, 100],
+                output_history_seq_ids=[1,],
+                output_history_sweep_time=[1, 16],
+                pred_occupancy=[1, 19, 200, 200, 16])


### PR DESCRIPTION
This PR adds a detailed README explaining how to deploy the FB-OCC model on the NVIDIA DRIVE platform using TensorRT:

- Model Export: Steps to generate an ONNX file and integrate custom operations for TensorRT.
- Cross-Compilation: Instructions to build TensorRT plugins for DRIVE Orin.
- Engine Creation: Commands for creating FP32/FP16 TensorRT engines.
- Evaluation: Workflow for preprocessing data, running inference, and validating results on DRIVE Orin.

The README also includes setup instructions, latency benchmarks, and a Docker-based environment for streamlined deployment. This provides a complete guide for deploying FB-OCC on NVIDIA DRIVE.